### PR TITLE
Add unit tests for core functionality

### DIFF
--- a/cmd/check-postgres-query/main.go
+++ b/cmd/check-postgres-query/main.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/jackc/pgpassfile"
+	"github.com/jackc/pgx/v5"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-plugin-sdk/sensu"
+)
+
+type Config struct {
+	sensu.PluginConfig
+	User         string
+	Password     string
+	IniFile      string
+	Hostname     string
+	Port         int
+	Database     string
+	Sslmode      string
+	Query        string
+	RegexPattern string
+	CheckTuples  bool
+	Warning      string
+	Critical     string
+	Timeout      int
+}
+
+var (
+	plugin = Config{
+		PluginConfig: sensu.PluginConfig{
+			Name:     "check-postgres-query",
+			Short:    "postgres query check",
+			Keyspace: "",
+		},
+	}
+
+	options = []sensu.ConfigOption{
+		&sensu.PluginConfigOption[string]{
+			Path:      "User",
+			Argument:  "user",
+			Shorthand: "u",
+			Usage:     "postgres user to connect",
+			Value:     &plugin.User,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "Password",
+			Argument:  "password",
+			Shorthand: "p",
+			Usage:     "Password for user",
+			Value:     &plugin.Password,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "pgpass file",
+			Argument:  "pgpass",
+			Shorthand: "f",
+			Usage:     "Location of .pgpass file for access to postgres",
+			Value:     &plugin.IniFile,
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "port",
+			Argument:  "port",
+			Shorthand: "P",
+			Usage:     "Port to connect to",
+			Value:     &plugin.Port,
+			Default:   5432,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "hostname",
+			Argument: "hostname",
+			Usage:    "Hostname to login to",
+			Value:    &plugin.Hostname,
+			Default:  "localhost",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "database",
+			Argument:  "database",
+			Shorthand: "d",
+			Usage:     "Database schema to connect to",
+			Value:     &plugin.Database,
+			Default:   "postgres",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "sslmode",
+			Argument:  "sslmode",
+			Shorthand: "s",
+			Usage:     "SSL mode for connecting to postgres",
+			Value:     &plugin.Sslmode,
+			Default:   "prefer",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "query",
+			Argument:  "query",
+			Shorthand: "q",
+			Usage:     "Database query to execute",
+			Value:     &plugin.Query,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "regex-pattern",
+			Argument:  "regex-pattern",
+			Shorthand: "r",
+			Usage:     "Regex pattern to match on query results and alert on if it does not match",
+			Value:     &plugin.RegexPattern,
+		},
+		&sensu.PluginConfigOption[bool]{
+			Path:      "check-tuples",
+			Argument:  "tuples",
+			Shorthand: "t",
+			Usage:     "Check against the number of tuples (rows) returned by the query",
+			Value:     &plugin.CheckTuples,
+			Default:   false,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "warning",
+			Argument:  "warning",
+			Shorthand: "w",
+			Usage:     "Warning threshold expression (e.g. 'value > 5')",
+			Value:     &plugin.Warning,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "critical",
+			Argument:  "critical",
+			Shorthand: "c",
+			Usage:     "Critical threshold expression (e.g. 'value > 10')",
+			Value:     &plugin.Critical,
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "timeout",
+			Argument:  "timeout",
+			Shorthand: "T",
+			Usage:     "Connection timeout (seconds)",
+			Value:     &plugin.Timeout,
+			Default:   10,
+		},
+	}
+)
+
+func main() {
+	check := sensu.NewCheck(&plugin.PluginConfig, options, checkArgs, executeCheck, false)
+	check.Execute()
+}
+
+func checkArgs(event *corev2.Event) (int, error) {
+	if plugin.Port <= 1 || plugin.Port >= 65535 {
+		return sensu.CheckStateCritical, fmt.Errorf("invalid port, should be a value between 1 and 65535")
+	}
+	if plugin.IniFile != "" {
+		if _, err := os.Stat(plugin.IniFile); os.IsNotExist(err) {
+			return sensu.CheckStateCritical, fmt.Errorf("unable to open the supplied config file %s", plugin.IniFile)
+		}
+	}
+	if plugin.Query == "" {
+		return sensu.CheckStateCritical, fmt.Errorf("query is required")
+	}
+
+	return sensu.CheckStateOK, nil
+}
+
+func executeCheck(event *corev2.Event) (int, error) {
+	ctx := context.Background()
+
+	var dbUser, dbPass, dbHost, dbDatabase string
+	var dbPort int
+	if plugin.IniFile != "" {
+		iniFile, err := pgpassfile.ReadPassfile(plugin.IniFile)
+		if err != nil {
+			return sensu.CheckStateCritical, fmt.Errorf("error parsing ini file: %v", err)
+		}
+		for _, entry := range iniFile.Entries {
+			dbUser = entry.Username
+			dbPass = entry.Password
+			dbHost = entry.Hostname
+			dbPort, _ = strconv.Atoi(entry.Port)
+			dbDatabase = entry.Database
+		}
+	} else {
+		dbUser = plugin.User
+		dbPass = plugin.Password
+		dbHost = plugin.Hostname
+		dbPort = plugin.Port
+		dbDatabase = plugin.Database
+	}
+
+	dataSourceName := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&connect_timeout=%d",
+		dbUser, dbPass, dbHost, dbPort, dbDatabase, plugin.Sslmode, plugin.Timeout)
+	db, err := pgx.Connect(ctx, dataSourceName)
+	if err != nil {
+		return sensu.CheckStateCritical, fmt.Errorf("error connecting to postgres: %v", err)
+	}
+	defer func() {
+		_ = db.Close(ctx)
+	}()
+
+	err = db.Ping(ctx)
+	if err != nil {
+		return sensu.CheckStateCritical, fmt.Errorf("error pinging postgres: %v", err)
+	}
+
+	// Execute query
+	rows, err := db.Query(ctx, plugin.Query)
+	if err != nil {
+		return sensu.CheckStateCritical, fmt.Errorf("unable to query PostgreSQL: %v", err)
+	}
+	defer rows.Close()
+
+	// Collect all rows
+	var results [][]interface{}
+	for rows.Next() {
+		values, err := rows.Values()
+		if err != nil {
+			return sensu.CheckStateCritical, fmt.Errorf("error reading query results: %v", err)
+		}
+		results = append(results, values)
+	}
+
+	if rows.Err() != nil {
+		return sensu.CheckStateCritical, fmt.Errorf("error iterating query results: %v", rows.Err())
+	}
+
+	// Determine the value to check
+	var value float64
+	if plugin.CheckTuples {
+		value = float64(len(results))
+	} else {
+		if len(results) == 0 || len(results[0]) == 0 {
+			return sensu.CheckStateCritical, fmt.Errorf("query returned no results")
+		}
+		// Convert first value to float
+		firstValue := results[0][0]
+		switch v := firstValue.(type) {
+		case int64:
+			value = float64(v)
+		case float64:
+			value = v
+		case string:
+			value, err = strconv.ParseFloat(v, 64)
+			if err != nil {
+				return sensu.CheckStateCritical, fmt.Errorf("unable to convert result to number: %v", err)
+			}
+		default:
+			return sensu.CheckStateCritical, fmt.Errorf("unable to convert result to number: unsupported type %T", v)
+		}
+	}
+
+	// Check critical threshold
+	if plugin.Critical != "" {
+		if matched, err := evaluateExpression(plugin.Critical, value); err != nil {
+			return sensu.CheckStateCritical, fmt.Errorf("error evaluating critical threshold: %v", err)
+		} else if matched {
+			return sensu.CheckStateCritical, fmt.Errorf("critical: Results: %v", results)
+		}
+	}
+
+	// Check warning threshold
+	if plugin.Warning != "" {
+		if matched, err := evaluateExpression(plugin.Warning, value); err != nil {
+			return sensu.CheckStateCritical, fmt.Errorf("error evaluating warning threshold: %v", err)
+		} else if matched {
+			return sensu.CheckStateWarning, fmt.Errorf("warning: Results: %v", results)
+		}
+	}
+
+	// Check regex pattern
+	if plugin.RegexPattern != "" {
+		if len(results) == 0 || len(results[0]) == 0 {
+			return sensu.CheckStateCritical, fmt.Errorf("query result is empty, cannot match regex")
+		}
+		resultStr := fmt.Sprintf("%v", results[0][0])
+		matched, err := regexp.MatchString(plugin.RegexPattern, resultStr)
+		if err != nil {
+			return sensu.CheckStateCritical, fmt.Errorf("error evaluating regex pattern: %v", err)
+		}
+		if !matched {
+			return sensu.CheckStateCritical, fmt.Errorf("query result %s doesn't match configured regex %s", resultStr, plugin.RegexPattern)
+		}
+	}
+
+	fmt.Print("Query OK")
+	return sensu.CheckStateOK, nil
+}
+
+// evaluateExpression evaluates simple threshold expressions like "value > 5", "value <= 10"
+// Supports operators: >, <, >=, <=, ==, !=
+func evaluateExpression(expr string, value float64) (bool, error) {
+	expr = strings.TrimSpace(expr)
+
+	// Parse expression: "value <op> <threshold>"
+	operators := []string{">=", "<=", "==", "!=", ">", "<"}
+	var operator string
+	var thresholdStr string
+
+	for _, op := range operators {
+		if strings.Contains(expr, op) {
+			parts := strings.SplitN(expr, op, 2)
+			if len(parts) != 2 {
+				continue
+			}
+			// Check if "value" is on the left side
+			if strings.TrimSpace(parts[0]) == "value" {
+				operator = op
+				thresholdStr = strings.TrimSpace(parts[1])
+				break
+			}
+		}
+	}
+
+	if operator == "" {
+		return false, fmt.Errorf("invalid expression format: %s (expected 'value <op> <number>')", expr)
+	}
+
+	threshold, err := strconv.ParseFloat(thresholdStr, 64)
+	if err != nil {
+		return false, fmt.Errorf("invalid threshold value: %s", thresholdStr)
+	}
+
+	// Evaluate the expression
+	switch operator {
+	case ">":
+		return value > threshold, nil
+	case "<":
+		return value < threshold, nil
+	case ">=":
+		return value >= threshold, nil
+	case "<=":
+		return value <= threshold, nil
+	case "==":
+		return value == threshold, nil
+	case "!=":
+		return value != threshold, nil
+	default:
+		return false, fmt.Errorf("unsupported operator: %s", operator)
+	}
+}

--- a/cmd/check-postgres-query/main_test.go
+++ b/cmd/check-postgres-query/main_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestEvaluateExpression(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		value   float64
+		want    bool
+		wantErr bool
+	}{
+		// Greater than
+		{name: "gt true", expr: "value > 5", value: 10, want: true},
+		{name: "gt false", expr: "value > 5", value: 3, want: false},
+		{name: "gt boundary false", expr: "value > 5", value: 5, want: false},
+
+		// Less than
+		{name: "lt true", expr: "value < 10", value: 5, want: true},
+		{name: "lt false", expr: "value < 10", value: 15, want: false},
+		{name: "lt boundary false", expr: "value < 10", value: 10, want: false},
+
+		// Greater than or equal
+		{name: "gte true above", expr: "value >= 5", value: 10, want: true},
+		{name: "gte true equal", expr: "value >= 5", value: 5, want: true},
+		{name: "gte false", expr: "value >= 5", value: 3, want: false},
+
+		// Less than or equal
+		{name: "lte true below", expr: "value <= 10", value: 5, want: true},
+		{name: "lte true equal", expr: "value <= 10", value: 10, want: true},
+		{name: "lte false", expr: "value <= 10", value: 15, want: false},
+
+		// Equal
+		{name: "eq true", expr: "value == 5", value: 5, want: true},
+		{name: "eq false", expr: "value == 5", value: 6, want: false},
+
+		// Not equal
+		{name: "ne true", expr: "value != 5", value: 6, want: true},
+		{name: "ne false", expr: "value != 5", value: 5, want: false},
+
+		// Floating point thresholds
+		{name: "float threshold", expr: "value > 3.14", value: 4.0, want: true},
+		{name: "float threshold false", expr: "value > 3.14", value: 2.0, want: false},
+
+		// Negative thresholds
+		{name: "negative threshold gt", expr: "value > -5", value: 0, want: true},
+		{name: "negative threshold lt", expr: "value < -5", value: -10, want: true},
+
+		// Zero value
+		{name: "zero value gt", expr: "value > 0", value: 0, want: false},
+		{name: "zero value eq", expr: "value == 0", value: 0, want: true},
+
+		// Whitespace handling
+		{name: "extra whitespace", expr: "  value  >  5  ", value: 10, want: true},
+
+		// Error cases
+		{name: "invalid expression no operator", expr: "value 5", value: 10, wantErr: true},
+		{name: "invalid threshold not a number", expr: "value > abc", value: 10, wantErr: true},
+		{name: "missing value keyword", expr: "x > 5", value: 10, wantErr: true},
+		{name: "empty expression", expr: "", value: 10, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := evaluateExpression(tt.expr, tt.value)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("evaluateExpression(%q, %f) expected error, got nil", tt.expr, tt.value)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("evaluateExpression(%q, %f) unexpected error: %v", tt.expr, tt.value, err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("evaluateExpression(%q, %f) = %v, want %v", tt.expr, tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/check-postgres-replication/main.go
+++ b/cmd/check-postgres-replication/main.go
@@ -220,7 +220,7 @@ func executeCheck(event *corev2.Event) (int, error) {
 	segSize, _ := strconv.ParseInt(sizeStr, 10, 64)
 	segBytes := segSize << 20 // Convert MB to bytes
 
-	connMaster.Close(ctx)
+	_ = connMaster.Close(ctx)
 
 	// Connect to slave
 	slaveDSN := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&connect_timeout=%d",
@@ -251,7 +251,7 @@ func executeCheck(event *corev2.Event) (int, error) {
 		return sensu.CheckStateCritical, fmt.Errorf("error querying slave WAL position: %v", err)
 	}
 
-	connSlave.Close(ctx)
+	_ = connSlave.Close(ctx)
 
 	// Calculate lag
 	lag, err := pgutil.ComputeLag(master, slave, segBytes)

--- a/cmd/check-postgres-replication/main.go
+++ b/cmd/check-postgres-replication/main.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+
+	"github.com/jackc/pgpassfile"
+	"github.com/jackc/pgx/v5"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-plugin-sdk/sensu"
+	"nmollerup/sensu-check-postgres/internal/pgutil"
+)
+
+type Config struct {
+	sensu.PluginConfig
+	User       string
+	Password   string
+	IniFile    string
+	MasterHost string
+	SlaveHost  string
+	Port       int
+	Database   string
+	Sslmode    string
+	Warning    int
+	Critical   int
+	Timeout    int
+}
+
+var (
+	plugin = Config{
+		PluginConfig: sensu.PluginConfig{
+			Name:     "check-postgres-replication",
+			Short:    "postgres replication check",
+			Keyspace: "",
+		},
+	}
+
+	options = []sensu.ConfigOption{
+		&sensu.PluginConfigOption[string]{
+			Path:      "User",
+			Argument:  "user",
+			Shorthand: "u",
+			Usage:     "postgres user to connect",
+			Value:     &plugin.User,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "Password",
+			Argument:  "password",
+			Shorthand: "p",
+			Usage:     "Password for user",
+			Value:     &plugin.Password,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "pgpass file",
+			Argument:  "pgpass",
+			Shorthand: "f",
+			Usage:     "Location of .pgpass file for access to postgres",
+			Value:     &plugin.IniFile,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "master_host",
+			Argument:  "master-host",
+			Shorthand: "m",
+			Usage:     "PostgreSQL master host",
+			Value:     &plugin.MasterHost,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "slave_host",
+			Argument:  "slave-host",
+			Shorthand: "s",
+			Usage:     "PostgreSQL slave host",
+			Value:     &plugin.SlaveHost,
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "port",
+			Argument:  "port",
+			Shorthand: "P",
+			Usage:     "Port to connect to",
+			Value:     &plugin.Port,
+			Default:   5432,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "database",
+			Argument:  "database",
+			Shorthand: "d",
+			Usage:     "Database schema to connect to",
+			Value:     &plugin.Database,
+			Default:   "postgres",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "sslmode",
+			Argument:  "sslmode",
+			Shorthand: "S",
+			Usage:     "SSL mode for connecting to postgres",
+			Value:     &plugin.Sslmode,
+			Default:   "prefer",
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "warning",
+			Argument:  "warning",
+			Shorthand: "w",
+			Usage:     "Warning threshold for replication lag (in MB)",
+			Value:     &plugin.Warning,
+			Default:   900,
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "critical",
+			Argument:  "critical",
+			Shorthand: "c",
+			Usage:     "Critical threshold for replication lag (in MB)",
+			Value:     &plugin.Critical,
+			Default:   1800,
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:     "timeout",
+			Argument: "timeout",
+			Usage:    "Connection timeout (seconds)",
+			Value:    &plugin.Timeout,
+			Default:  2,
+		},
+	}
+)
+
+func main() {
+	check := sensu.NewCheck(&plugin.PluginConfig, options, checkArgs, executeCheck, false)
+	check.Execute()
+}
+
+func checkArgs(event *corev2.Event) (int, error) {
+	if plugin.Port <= 1 || plugin.Port >= 65535 {
+		return sensu.CheckStateCritical, fmt.Errorf("invalid port, should be a value between 1 and 65535")
+	}
+	if plugin.IniFile != "" {
+		if _, err := os.Stat(plugin.IniFile); os.IsNotExist(err) {
+			return sensu.CheckStateCritical, fmt.Errorf("unable to open the supplied config file %s", plugin.IniFile)
+		}
+	}
+	if plugin.MasterHost == "" {
+		return sensu.CheckStateCritical, fmt.Errorf("master-host is required")
+	}
+	if plugin.SlaveHost == "" {
+		return sensu.CheckStateCritical, fmt.Errorf("slave-host is required")
+	}
+	if plugin.MasterHost == plugin.SlaveHost {
+		return sensu.CheckStateCritical, fmt.Errorf("master and slave cannot be the same host")
+	}
+
+	return sensu.CheckStateOK, nil
+}
+
+func executeCheck(event *corev2.Event) (int, error) {
+	ctx := context.Background()
+
+	var dbUser, dbPass, dbDatabase string
+	var dbPort int
+	if plugin.IniFile != "" {
+		iniFile, err := pgpassfile.ReadPassfile(plugin.IniFile)
+		if err != nil {
+			return sensu.CheckStateCritical, fmt.Errorf("error parsing ini file: %v", err)
+		}
+		for _, entry := range iniFile.Entries {
+			dbUser = entry.Username
+			dbPass = entry.Password
+			dbPort, _ = strconv.Atoi(entry.Port)
+			dbDatabase = entry.Database
+		}
+	} else {
+		dbUser = plugin.User
+		dbPass = plugin.Password
+		dbPort = plugin.Port
+		dbDatabase = plugin.Database
+	}
+
+	// Connect to master
+	masterDSN := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&connect_timeout=%d",
+		dbUser, dbPass, plugin.MasterHost, dbPort, dbDatabase, plugin.Sslmode, plugin.Timeout)
+	connMaster, err := pgx.Connect(ctx, masterDSN)
+	if err != nil {
+		return sensu.CheckStateCritical, fmt.Errorf("error connecting to master postgres: %v", err)
+	}
+	defer func() {
+		_ = connMaster.Close(ctx)
+	}()
+
+	// Check PostgreSQL version
+	isPG9, err := pgutil.CheckVersionNewerThanPostgres9(ctx, connMaster)
+	if err != nil {
+		return sensu.CheckStateCritical, fmt.Errorf("error checking postgres version: %v", err)
+	}
+
+	// Get master WAL position
+	var master string
+	var walQuery string
+	if isPG9 {
+		walQuery = "SELECT pg_current_xlog_location()"
+	} else {
+		walQuery = "SELECT pg_current_wal_lsn()"
+	}
+	err = connMaster.QueryRow(ctx, walQuery).Scan(&master)
+	if err != nil {
+		return sensu.CheckStateCritical, fmt.Errorf("error querying master WAL position: %v", err)
+	}
+
+	// Get WAL segment size
+	var walSegmentSize string
+	err = connMaster.QueryRow(ctx, "SHOW wal_segment_size").Scan(&walSegmentSize)
+	if err != nil {
+		return sensu.CheckStateCritical, fmt.Errorf("error querying wal_segment_size: %v", err)
+	}
+
+	// Parse wal_segment_size (e.g., "16MB" -> 16777216 bytes)
+	re := regexp.MustCompile(`\d+`)
+	sizeStr := re.FindString(walSegmentSize)
+	if sizeStr == "" {
+		return sensu.CheckStateCritical, fmt.Errorf("unable to parse wal_segment_size: %s", walSegmentSize)
+	}
+	segSize, _ := strconv.ParseInt(sizeStr, 10, 64)
+	segBytes := segSize << 20 // Convert MB to bytes
+
+	connMaster.Close(ctx)
+
+	// Connect to slave
+	slaveDSN := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&connect_timeout=%d",
+		dbUser, dbPass, plugin.SlaveHost, dbPort, dbDatabase, plugin.Sslmode, plugin.Timeout)
+	connSlave, err := pgx.Connect(ctx, slaveDSN)
+	if err != nil {
+		return sensu.CheckStateCritical, fmt.Errorf("error connecting to slave postgres: %v", err)
+	}
+	defer func() {
+		_ = connSlave.Close(ctx)
+	}()
+
+	// Check slave PostgreSQL version
+	isPG9Slave, err := pgutil.CheckVersionNewerThanPostgres9(ctx, connSlave)
+	if err != nil {
+		return sensu.CheckStateCritical, fmt.Errorf("error checking slave postgres version: %v", err)
+	}
+
+	// Get slave WAL position
+	var slave string
+	if isPG9Slave {
+		walQuery = "SELECT pg_last_xlog_receive_location()"
+	} else {
+		walQuery = "SELECT pg_last_wal_replay_lsn()"
+	}
+	err = connSlave.QueryRow(ctx, walQuery).Scan(&slave)
+	if err != nil {
+		return sensu.CheckStateCritical, fmt.Errorf("error querying slave WAL position: %v", err)
+	}
+
+	connSlave.Close(ctx)
+
+	// Calculate lag
+	lag, err := pgutil.ComputeLag(master, slave, segBytes)
+	if err != nil {
+		return sensu.CheckStateCritical, fmt.Errorf("error computing lag: %v", err)
+	}
+
+	lagInMB := float64(abs(lag)) / 1024 / 1024
+	message := fmt.Sprintf("replication delayed by %.2fMB :: master:%s slave:%s m_segbytes:%d",
+		lagInMB, master, slave, segBytes)
+
+	if lagInMB >= float64(plugin.Critical) {
+		return sensu.CheckStateCritical, fmt.Errorf("critical: %s", message)
+	} else if lagInMB >= float64(plugin.Warning) {
+		return sensu.CheckStateWarning, fmt.Errorf("warning: %s", message)
+	}
+
+	fmt.Print(message)
+	return sensu.CheckStateOK, nil
+}
+
+func abs(n int64) int64 {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/cmd/check-postgres-replication/main_test.go
+++ b/cmd/check-postgres-replication/main_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestAbs(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int64
+		want int64
+	}{
+		{name: "positive number", n: 42, want: 42},
+		{name: "negative number", n: -42, want: 42},
+		{name: "zero", n: 0, want: 0},
+		{name: "large positive", n: 1099511627776, want: 1099511627776},
+		{name: "large negative", n: -1099511627776, want: 1099511627776},
+		{name: "negative one", n: -1, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := abs(tt.n)
+			if got != tt.want {
+				t.Errorf("abs(%d) = %d, want %d", tt.n, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/metric-postgres-connections/main.go
+++ b/cmd/metric-postgres-connections/main.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgpassfile"
+	"github.com/jackc/pgx/v5"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-plugin-sdk/sensu"
+)
+
+type Config struct {
+	sensu.PluginConfig
+	User     string
+	Password string
+	IniFile  string
+	Hostname string
+	Port     int
+	Database string
+	Sslmode  string
+	Scheme   string
+	Timeout  int
+}
+
+var (
+	plugin = Config{
+		PluginConfig: sensu.PluginConfig{
+			Name:     "metric-postgres-connections",
+			Short:    "postgres connections metric",
+			Keyspace: "",
+		},
+	}
+
+	options = []sensu.ConfigOption{
+		&sensu.PluginConfigOption[string]{
+			Path:      "User",
+			Argument:  "user",
+			Shorthand: "u",
+			Usage:     "postgres user to connect",
+			Value:     &plugin.User,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "Password",
+			Argument:  "password",
+			Shorthand: "p",
+			Usage:     "Password for user",
+			Value:     &plugin.Password,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "pgpass file",
+			Argument:  "pgpass",
+			Shorthand: "f",
+			Usage:     "Location of .pgpass file for access to postgres",
+			Value:     &plugin.IniFile,
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "port",
+			Argument:  "port",
+			Shorthand: "P",
+			Usage:     "Port to connect to",
+			Value:     &plugin.Port,
+			Default:   5432,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "hostname",
+			Argument: "hostname",
+			Usage:    "Hostname to login to",
+			Value:    &plugin.Hostname,
+			Default:  "localhost",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "database",
+			Argument:  "database",
+			Shorthand: "d",
+			Usage:     "Database schema to connect to",
+			Value:     &plugin.Database,
+			Default:   "postgres",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "sslmode",
+			Argument:  "sslmode",
+			Shorthand: "s",
+			Usage:     "SSL mode for connecting to postgres",
+			Value:     &plugin.Sslmode,
+			Default:   "prefer",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "scheme",
+			Argument: "scheme",
+			Usage:    "Metric naming scheme",
+			Value:    &plugin.Scheme,
+			Default:  "postgresql",
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "timeout",
+			Argument:  "timeout",
+			Shorthand: "T",
+			Usage:     "Connection timeout (seconds)",
+			Value:     &plugin.Timeout,
+			Default:   10,
+		},
+	}
+)
+
+func main() {
+	metric := sensu.NewGoHandler(&plugin.PluginConfig, options, checkArgs, executeMetric)
+	metric.Execute()
+}
+
+func checkArgs(_ *corev2.Event) error {
+	if plugin.Port <= 1 || plugin.Port >= 65535 {
+		return fmt.Errorf("invalid port, should be a value between 1 and 65535")
+	}
+	if plugin.IniFile != "" {
+		if _, err := os.Stat(plugin.IniFile); os.IsNotExist(err) {
+			return fmt.Errorf("unable to open the supplied config file %s", plugin.IniFile)
+		}
+	}
+	return nil
+}
+
+func executeMetric(_ *corev2.Event) error {
+	ctx := context.Background()
+	timestamp := time.Now().Unix()
+
+	var dbUser, dbPass, dbHost, dbDatabase string
+	var dbPort int
+	if plugin.IniFile != "" {
+		iniFile, err := pgpassfile.ReadPassfile(plugin.IniFile)
+		if err != nil {
+			return fmt.Errorf("error parsing ini file: %v", err)
+		}
+		for _, entry := range iniFile.Entries {
+			dbUser = entry.Username
+			dbPass = entry.Password
+			dbHost = entry.Hostname
+			dbPort, _ = strconv.Atoi(entry.Port)
+			dbDatabase = entry.Database
+		}
+	} else {
+		dbUser = plugin.User
+		dbPass = plugin.Password
+		dbHost = plugin.Hostname
+		dbPort = plugin.Port
+		dbDatabase = plugin.Database
+	}
+
+	dataSourceName := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&connect_timeout=%d",
+		dbUser, dbPass, dbHost, dbPort, dbDatabase, plugin.Sslmode, plugin.Timeout)
+	db, err := pgx.Connect(ctx, dataSourceName)
+	if err != nil {
+		return fmt.Errorf("error connecting to postgres: %v", err)
+	}
+	defer func() {
+		_ = db.Close(ctx)
+	}()
+
+	// Determine wait column name based on PostgreSQL version
+	var waitCol string
+	query := `select case when count(*) = 1 then 'waiting' else 
+		'case when wait_event_type is null then false else true end' end as wait_col
+		from information_schema.columns
+		where table_name = 'pg_stat_activity' and table_schema = 'pg_catalog'
+		and column_name = 'waiting'`
+	err = db.QueryRow(ctx, query).Scan(&waitCol)
+	if err != nil {
+		return fmt.Errorf("error querying wait column: %v", err)
+	}
+
+	// Query connection metrics
+	query = fmt.Sprintf(`select count(*), %s as waiting from pg_stat_activity
+		where datname = '%s' group by %s`, waitCol, dbDatabase, waitCol)
+
+	rows, err := db.Query(ctx, query)
+	if err != nil {
+		return fmt.Errorf("error querying connections: %v", err)
+	}
+	defer rows.Close()
+
+	active := 0
+	waiting := 0
+	for rows.Next() {
+		var count int
+		var isWaiting string
+		err = rows.Scan(&count, &isWaiting)
+		if err != nil {
+			return fmt.Errorf("error scanning row: %v", err)
+		}
+		if isWaiting == "t" {
+			waiting = count
+		} else if isWaiting == "f" {
+			active = count
+		}
+	}
+
+	total := active + waiting
+
+	// Output metrics in Graphite format
+	fmt.Printf("%s.connections.%s.active %d %d\n", plugin.Scheme, dbDatabase, active, timestamp)
+	fmt.Printf("%s.connections.%s.waiting %d %d\n", plugin.Scheme, dbDatabase, waiting, timestamp)
+	fmt.Printf("%s.connections.%s.total %d %d\n", plugin.Scheme, dbDatabase, total, timestamp)
+
+	return nil
+}

--- a/cmd/metric-postgres-connections/main.go
+++ b/cmd/metric-postgres-connections/main.go
@@ -190,9 +190,10 @@ func executeMetric(_ *corev2.Event) error {
 		if err != nil {
 			return fmt.Errorf("error scanning row: %v", err)
 		}
-		if isWaiting == "t" {
+		switch isWaiting {
+		case "t":
 			waiting = count
-		} else if isWaiting == "f" {
+		case "f":
 			active = count
 		}
 	}

--- a/cmd/metric-postgres-dbsize/main.go
+++ b/cmd/metric-postgres-dbsize/main.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgpassfile"
+	"github.com/jackc/pgx/v5"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-plugin-sdk/sensu"
+)
+
+type Config struct {
+	sensu.PluginConfig
+	User     string
+	Password string
+	IniFile  string
+	Hostname string
+	Port     int
+	Database string
+	Sslmode  string
+	Scheme   string
+	Timeout  int
+}
+
+var (
+	plugin = Config{
+		PluginConfig: sensu.PluginConfig{
+			Name:     "metric-postgres-dbsize",
+			Short:    "postgres database size metric",
+			Keyspace: "",
+		},
+	}
+
+	options = []sensu.ConfigOption{
+		&sensu.PluginConfigOption[string]{
+			Path:      "User",
+			Argument:  "user",
+			Shorthand: "u",
+			Usage:     "postgres user to connect",
+			Value:     &plugin.User,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "Password",
+			Argument:  "password",
+			Shorthand: "p",
+			Usage:     "Password for user",
+			Value:     &plugin.Password,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "pgpass file",
+			Argument:  "pgpass",
+			Shorthand: "f",
+			Usage:     "Location of .pgpass file for access to postgres",
+			Value:     &plugin.IniFile,
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "port",
+			Argument:  "port",
+			Shorthand: "P",
+			Usage:     "Port to connect to",
+			Value:     &plugin.Port,
+			Default:   5432,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "hostname",
+			Argument: "hostname",
+			Usage:    "Hostname to login to",
+			Value:    &plugin.Hostname,
+			Default:  "localhost",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "database",
+			Argument:  "database",
+			Shorthand: "d",
+			Usage:     "Database schema to connect to",
+			Value:     &plugin.Database,
+			Default:   "postgres",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "sslmode",
+			Argument:  "sslmode",
+			Shorthand: "s",
+			Usage:     "SSL mode for connecting to postgres",
+			Value:     &plugin.Sslmode,
+			Default:   "prefer",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "scheme",
+			Argument: "scheme",
+			Usage:    "Metric naming scheme",
+			Value:    &plugin.Scheme,
+			Default:  "postgresql",
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "timeout",
+			Argument:  "timeout",
+			Shorthand: "T",
+			Usage:     "Connection timeout (seconds)",
+			Value:     &plugin.Timeout,
+			Default:   10,
+		},
+	}
+)
+
+func main() {
+	metric := sensu.NewGoHandler(&plugin.PluginConfig, options, checkArgs, executeMetric)
+	metric.Execute()
+}
+
+func checkArgs(_ *corev2.Event) error {
+	if plugin.Port <= 1 || plugin.Port >= 65535 {
+		return fmt.Errorf("invalid port, should be a value between 1 and 65535")
+	}
+	if plugin.IniFile != "" {
+		if _, err := os.Stat(plugin.IniFile); os.IsNotExist(err) {
+			return fmt.Errorf("unable to open the supplied config file %s", plugin.IniFile)
+		}
+	}
+	return nil
+}
+
+func executeMetric(_ *corev2.Event) error {
+	ctx := context.Background()
+	timestamp := time.Now().Unix()
+
+	var dbUser, dbPass, dbHost, dbDatabase string
+	var dbPort int
+	if plugin.IniFile != "" {
+		iniFile, err := pgpassfile.ReadPassfile(plugin.IniFile)
+		if err != nil {
+			return fmt.Errorf("error parsing ini file: %v", err)
+		}
+		for _, entry := range iniFile.Entries {
+			dbUser = entry.Username
+			dbPass = entry.Password
+			dbHost = entry.Hostname
+			dbPort, _ = strconv.Atoi(entry.Port)
+			dbDatabase = entry.Database
+		}
+	} else {
+		dbUser = plugin.User
+		dbPass = plugin.Password
+		dbHost = plugin.Hostname
+		dbPort = plugin.Port
+		dbDatabase = plugin.Database
+	}
+
+	dataSourceName := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&connect_timeout=%d",
+		dbUser, dbPass, dbHost, dbPort, dbDatabase, plugin.Sslmode, plugin.Timeout)
+	db, err := pgx.Connect(ctx, dataSourceName)
+	if err != nil {
+		return fmt.Errorf("error connecting to postgres: %v", err)
+	}
+	defer func() {
+		_ = db.Close(ctx)
+	}()
+
+	var size int64
+	query := fmt.Sprintf("SELECT pg_database_size('%s')", dbDatabase)
+	err = db.QueryRow(ctx, query).Scan(&size)
+	if err != nil {
+		return fmt.Errorf("error querying database size: %v", err)
+	}
+
+	fmt.Printf("%s.size.%s %d %d\n", plugin.Scheme, dbDatabase, size, timestamp)
+
+	return nil
+}

--- a/cmd/metric-postgres-locks/main.go
+++ b/cmd/metric-postgres-locks/main.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgpassfile"
+	"github.com/jackc/pgx/v5"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-plugin-sdk/sensu"
+)
+
+type Config struct {
+	sensu.PluginConfig
+	User     string
+	Password string
+	IniFile  string
+	Hostname string
+	Port     int
+	Database string
+	Sslmode  string
+	Scheme   string
+	Timeout  int
+}
+
+var (
+	plugin = Config{
+		PluginConfig: sensu.PluginConfig{
+			Name:     "metric-postgres-locks",
+			Short:    "postgres locks metric",
+			Keyspace: "",
+		},
+	}
+
+	options = []sensu.ConfigOption{
+		&sensu.PluginConfigOption[string]{
+			Path:      "User",
+			Argument:  "user",
+			Shorthand: "u",
+			Usage:     "postgres user to connect",
+			Value:     &plugin.User,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "Password",
+			Argument:  "password",
+			Shorthand: "p",
+			Usage:     "Password for user",
+			Value:     &plugin.Password,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "pgpass file",
+			Argument:  "pgpass",
+			Shorthand: "f",
+			Usage:     "Location of .pgpass file for access to postgres",
+			Value:     &plugin.IniFile,
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "port",
+			Argument:  "port",
+			Shorthand: "P",
+			Usage:     "Port to connect to",
+			Value:     &plugin.Port,
+			Default:   5432,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "hostname",
+			Argument: "hostname",
+			Usage:    "Hostname to login to",
+			Value:    &plugin.Hostname,
+			Default:  "localhost",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "database",
+			Argument:  "database",
+			Shorthand: "d",
+			Usage:     "Database schema to connect to",
+			Value:     &plugin.Database,
+			Default:   "postgres",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "sslmode",
+			Argument:  "sslmode",
+			Shorthand: "s",
+			Usage:     "SSL mode for connecting to postgres",
+			Value:     &plugin.Sslmode,
+			Default:   "prefer",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "scheme",
+			Argument: "scheme",
+			Usage:    "Metric naming scheme",
+			Value:    &plugin.Scheme,
+			Default:  "postgresql",
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "timeout",
+			Argument:  "timeout",
+			Shorthand: "T",
+			Usage:     "Connection timeout (seconds)",
+			Value:     &plugin.Timeout,
+			Default:   10,
+		},
+	}
+)
+
+func main() {
+	metric := sensu.NewGoHandler(&plugin.PluginConfig, options, checkArgs, executeMetric)
+	metric.Execute()
+}
+
+func checkArgs(_ *corev2.Event) error {
+	if plugin.Port <= 1 || plugin.Port >= 65535 {
+		return fmt.Errorf("invalid port, should be a value between 1 and 65535")
+	}
+	if plugin.IniFile != "" {
+		if _, err := os.Stat(plugin.IniFile); os.IsNotExist(err) {
+			return fmt.Errorf("unable to open the supplied config file %s", plugin.IniFile)
+		}
+	}
+	return nil
+}
+
+func executeMetric(_ *corev2.Event) error {
+	ctx := context.Background()
+	timestamp := time.Now().Unix()
+
+	var dbUser, dbPass, dbHost, dbDatabase string
+	var dbPort int
+	if plugin.IniFile != "" {
+		iniFile, err := pgpassfile.ReadPassfile(plugin.IniFile)
+		if err != nil {
+			return fmt.Errorf("error parsing ini file: %v", err)
+		}
+		for _, entry := range iniFile.Entries {
+			dbUser = entry.Username
+			dbPass = entry.Password
+			dbHost = entry.Hostname
+			dbPort, _ = strconv.Atoi(entry.Port)
+			dbDatabase = entry.Database
+		}
+	} else {
+		dbUser = plugin.User
+		dbPass = plugin.Password
+		dbHost = plugin.Hostname
+		dbPort = plugin.Port
+		dbDatabase = plugin.Database
+	}
+
+	dataSourceName := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&connect_timeout=%d",
+		dbUser, dbPass, dbHost, dbPort, dbDatabase, plugin.Sslmode, plugin.Timeout)
+	db, err := pgx.Connect(ctx, dataSourceName)
+	if err != nil {
+		return fmt.Errorf("error connecting to postgres: %v", err)
+	}
+	defer func() {
+		_ = db.Close(ctx)
+	}()
+
+	query := fmt.Sprintf(`SELECT mode, count(mode) AS count FROM pg_locks
+		WHERE database = (SELECT oid FROM pg_database WHERE datname = '%s')
+		GROUP BY mode`, dbDatabase)
+
+	rows, err := db.Query(ctx, query)
+	if err != nil {
+		return fmt.Errorf("error querying locks: %v", err)
+	}
+	defer rows.Close()
+
+	locks := make(map[string]int)
+	for rows.Next() {
+		var mode string
+		var count int
+		err = rows.Scan(&mode, &count)
+		if err != nil {
+			return fmt.Errorf("error scanning row: %v", err)
+		}
+		// Convert mode to lowercase for metric name
+		lockType := strings.ToLower(strings.ReplaceAll(mode, "Lock", "lock"))
+		locks[lockType] = count
+	}
+
+	// Output metrics
+	for lockType, count := range locks {
+		fmt.Printf("%s.locks.%s.%s %d %d\n", plugin.Scheme, dbDatabase, lockType, count, timestamp)
+	}
+
+	return nil
+}

--- a/internal/pgutil/pgutil.go
+++ b/internal/pgutil/pgutil.go
@@ -1,0 +1,82 @@
+package pgutil
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// CheckVersionNewerThanPostgres9 returns true if the PostgreSQL version is 9.x
+// (between 9.0 and less than 10.0)
+func CheckVersionNewerThanPostgres9(ctx context.Context, conn *pgx.Conn) (bool, error) {
+	var pgVersion string
+	err := conn.QueryRow(ctx, "SELECT current_setting('server_version')").Scan(&pgVersion)
+	if err != nil {
+		return false, fmt.Errorf("error querying server version: %v", err)
+	}
+
+	// Extract version number (e.g., "9.6.24" or "14.5")
+	versionParts := strings.Split(pgVersion, " ")
+	if len(versionParts) == 0 {
+		return false, fmt.Errorf("unable to parse version string: %s", pgVersion)
+	}
+
+	version := versionParts[0]
+	majorMinor := strings.Split(version, ".")
+	if len(majorMinor) < 2 {
+		return false, fmt.Errorf("unable to parse version number: %s", version)
+	}
+
+	major, err := strconv.Atoi(majorMinor[0])
+	if err != nil {
+		return false, fmt.Errorf("unable to parse major version: %v", err)
+	}
+
+	// PostgreSQL 9.x versions
+	if major == 9 {
+		return true, nil
+	}
+
+	// PostgreSQL 10+ versions
+	return false, nil
+}
+
+// ComputeLag calculates the replication lag in bytes between master and slave
+// WAL positions. Returns the lag in bytes.
+func ComputeLag(master, slave string, segBytes int64) (int64, error) {
+	// WAL position format: segment/offset (e.g., "B0/B4031000")
+	masterParts := strings.Split(master, "/")
+	slaveParts := strings.Split(slave, "/")
+
+	if len(masterParts) != 2 || len(slaveParts) != 2 {
+		return 0, fmt.Errorf("invalid WAL position format")
+	}
+
+	// Parse hexadecimal values
+	mSegment, err := strconv.ParseInt(masterParts[0], 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing master segment: %v", err)
+	}
+
+	mOffset, err := strconv.ParseInt(masterParts[1], 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing master offset: %v", err)
+	}
+
+	sSegment, err := strconv.ParseInt(slaveParts[0], 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing slave segment: %v", err)
+	}
+
+	sOffset, err := strconv.ParseInt(slaveParts[1], 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing slave offset: %v", err)
+	}
+
+	// Calculate lag: (segment_diff * segment_size) + offset_diff
+	lag := ((mSegment - sSegment) * segBytes) + (mOffset - sOffset)
+	return lag, nil
+}

--- a/internal/pgutil/pgutil_test.go
+++ b/internal/pgutil/pgutil_test.go
@@ -1,0 +1,133 @@
+package pgutil
+
+import (
+	"testing"
+)
+
+func TestComputeLag(t *testing.T) {
+	tests := []struct {
+		name     string
+		master   string
+		slave    string
+		segBytes int64
+		wantLag  int64
+		wantErr  bool
+	}{
+		{
+			name:     "zero lag when positions are equal",
+			master:   "B0/B4031000",
+			slave:    "B0/B4031000",
+			segBytes: 16777216,
+			wantLag:  0,
+			wantErr:  false,
+		},
+		{
+			name:     "positive lag when master is ahead by offset",
+			master:   "0/2000",
+			slave:    "0/1000",
+			segBytes: 16777216,
+			wantLag:  4096, // 0x2000 - 0x1000 = 0x1000 = 4096
+			wantErr:  false,
+		},
+		{
+			name:     "positive lag across segments",
+			master:   "2/0",
+			slave:    "1/0",
+			segBytes: 16777216,
+			wantLag:  16777216, // 1 segment difference
+			wantErr:  false,
+		},
+		{
+			name:     "lag with both segment and offset difference",
+			master:   "3/1000",
+			slave:    "1/0",
+			segBytes: 16777216,
+			wantLag:  2*16777216 + 4096, // 2 segments + 0x1000 offset
+			wantErr:  false,
+		},
+		{
+			name:     "negative lag when slave is ahead",
+			master:   "0/1000",
+			slave:    "0/2000",
+			segBytes: 16777216,
+			wantLag:  -4096,
+			wantErr:  false,
+		},
+		{
+			name:     "invalid master format missing slash",
+			master:   "B0B4031000",
+			slave:    "B0/B4031000",
+			segBytes: 16777216,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid slave format missing slash",
+			master:   "B0/B4031000",
+			slave:    "B0B4031000",
+			segBytes: 16777216,
+			wantErr:  true,
+		},
+		{
+			name:     "empty master",
+			master:   "",
+			slave:    "B0/B4031000",
+			segBytes: 16777216,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid hex in master segment",
+			master:   "ZZ/1000",
+			slave:    "0/1000",
+			segBytes: 16777216,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid hex in master offset",
+			master:   "0/ZZZZ",
+			slave:    "0/1000",
+			segBytes: 16777216,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid hex in slave segment",
+			master:   "0/1000",
+			slave:    "GG/1000",
+			segBytes: 16777216,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid hex in slave offset",
+			master:   "0/1000",
+			slave:    "0/XXXX",
+			segBytes: 16777216,
+			wantErr:  true,
+		},
+		{
+			name:     "realistic WAL positions",
+			master:   "B0/B4031000",
+			slave:    "B0/B4030000",
+			segBytes: 16777216,
+			wantLag:  4096, // 0xB4031000 - 0xB4030000 = 0x1000 = 4096
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lag, err := ComputeLag(tt.master, tt.slave, tt.segBytes)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ComputeLag() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ComputeLag() unexpected error: %v", err)
+				return
+			}
+			if lag != tt.wantLag {
+				t.Errorf("ComputeLag() = %d, want %d", lag, tt.wantLag)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Add unit tests for the core logic that can be tested without a live database:

- **pgutil**: 13 test cases for `ComputeLag` — WAL replication lag calculation (zero/positive/negative lag, cross-segment, invalid formats, bad hex)
- **check-postgres-query**: 27 test cases for `evaluateExpression` — threshold evaluation (all 6 operators, boundary conditions, floats, negatives, whitespace, error cases)
- **check-postgres-replication**: 6 test cases for `abs` helper