### PR TITLE
Add remaining metric collector plugins

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,7 +35,6 @@ builds:
     env:
     - CGO_ENABLED=0
     ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
-    # Set the binary output location to bin/ so archive will comply with Sensu Go Asset structure
     binary: bin/check-postgres-connections
     goos:
       - linux
@@ -59,6 +58,201 @@ builds:
       - windows_386
       - windows_amd64
 
+  - main: ./cmd/metric-postgres-statsbgwriter/main.go
+    id: "metric-postgres-statsbgwriter"
+    env:
+    - CGO_ENABLED=0
+    ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
+    binary: bin/metric-postgres-statsbgwriter
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - 386
+      - arm
+      - arm64
+    goarm:
+      - 5
+      - 6
+      - 7
+    targets:
+      - linux_386
+      - linux_amd64
+      - linux_arm_5
+      - linux_arm_6
+      - linux_arm_7
+      - linux_arm64
+      - windows_386
+      - windows_amd64
+
+  - main: ./cmd/metric-postgres-statsdb/main.go
+    id: "metric-postgres-statsdb"
+    env:
+    - CGO_ENABLED=0
+    ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
+    binary: bin/metric-postgres-statsdb
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - 386
+      - arm
+      - arm64
+    goarm:
+      - 5
+      - 6
+      - 7
+    targets:
+      - linux_386
+      - linux_amd64
+      - linux_arm_5
+      - linux_arm_6
+      - linux_arm_7
+      - linux_arm64
+      - windows_386
+      - windows_amd64
+
+  - main: ./cmd/metric-postgres-statsio/main.go
+    id: "metric-postgres-statsio"
+    env:
+    - CGO_ENABLED=0
+    ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
+    binary: bin/metric-postgres-statsio
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - 386
+      - arm
+      - arm64
+    goarm:
+      - 5
+      - 6
+      - 7
+    targets:
+      - linux_386
+      - linux_amd64
+      - linux_arm_5
+      - linux_arm_6
+      - linux_arm_7
+      - linux_arm64
+      - windows_386
+      - windows_amd64
+
+  - main: ./cmd/metric-postgres-statstable/main.go
+    id: "metric-postgres-statstable"
+    env:
+    - CGO_ENABLED=0
+    ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
+    binary: bin/metric-postgres-statstable
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - 386
+      - arm
+      - arm64
+    goarm:
+      - 5
+      - 6
+      - 7
+    targets:
+      - linux_386
+      - linux_amd64
+      - linux_arm_5
+      - linux_arm_6
+      - linux_arm_7
+      - linux_arm64
+      - windows_386
+      - windows_amd64
+
+  - main: ./cmd/metric-postgres-graphite/main.go
+    id: "metric-postgres-graphite"
+    env:
+    - CGO_ENABLED=0
+    ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
+    binary: bin/metric-postgres-graphite
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - 386
+      - arm
+      - arm64
+    goarm:
+      - 5
+      - 6
+      - 7
+    targets:
+      - linux_386
+      - linux_amd64
+      - linux_arm_5
+      - linux_arm_6
+      - linux_arm_7
+      - linux_arm64
+      - windows_386
+      - windows_amd64
+
+  - main: ./cmd/metric-postgres-relation-size/main.go
+    id: "metric-postgres-relation-size"
+    env:
+    - CGO_ENABLED=0
+    ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
+    binary: bin/metric-postgres-relation-size
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - 386
+      - arm
+      - arm64
+    goarm:
+      - 5
+      - 6
+      - 7
+    targets:
+      - linux_386
+      - linux_amd64
+      - linux_arm_5
+      - linux_arm_6
+      - linux_arm_7
+      - linux_arm64
+      - windows_386
+      - windows_amd64
+
+  - main: ./cmd/metrics-postgres-query/main.go
+    id: "metrics-postgres-query"
+    env:
+    - CGO_ENABLED=0
+    ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
+    binary: bin/metrics-postgres-query
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - 386
+      - arm
+      - arm64
+    goarm:
+      - 5
+      - 6
+      - 7
+    targets:
+      - linux_386
+      - linux_amd64
+      - linux_arm_5
+      - linux_arm_6
+      - linux_arm_7
+      - linux_arm64
+      - windows_386
+      - windows_amd64
 
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_sha512-checksums.txt"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,25 +1,13 @@
+version: 2
+
 project_name: "sensu-check-postgres"
 builds:
-  # List of builds
   - main: ./cmd/check-postgres-alive/main.go
     id: "check-postgres-alive"
     env:
-    - CGO_ENABLED=0
+      - CGO_ENABLED=0
     ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
-    # Set the binary output location to bin/ so archive will comply with Sensu Go Asset structure
     binary: bin/check-postgres-alive
-    goos:
-      - linux
-      - windows
-    goarch:
-      - amd64
-      - 386
-      - arm
-      - arm64
-    goarm:
-      - 5
-      - 6
-      - 7
     targets:
       - linux_386
       - linux_amd64
@@ -33,21 +21,9 @@ builds:
   - main: ./cmd/check-postgres-connections/main.go
     id: "check-postgres-connections"
     env:
-    - CGO_ENABLED=0
+      - CGO_ENABLED=0
     ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
     binary: bin/check-postgres-connections
-    goos:
-      - linux
-      - windows
-    goarch:
-      - amd64
-      - 386
-      - arm
-      - arm64
-    goarm:
-      - 5
-      - 6
-      - 7
     targets:
       - linux_386
       - linux_amd64
@@ -61,21 +37,9 @@ builds:
   - main: ./cmd/metric-postgres-statsbgwriter/main.go
     id: "metric-postgres-statsbgwriter"
     env:
-    - CGO_ENABLED=0
+      - CGO_ENABLED=0
     ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
     binary: bin/metric-postgres-statsbgwriter
-    goos:
-      - linux
-      - windows
-    goarch:
-      - amd64
-      - 386
-      - arm
-      - arm64
-    goarm:
-      - 5
-      - 6
-      - 7
     targets:
       - linux_386
       - linux_amd64
@@ -89,21 +53,9 @@ builds:
   - main: ./cmd/metric-postgres-statsdb/main.go
     id: "metric-postgres-statsdb"
     env:
-    - CGO_ENABLED=0
+      - CGO_ENABLED=0
     ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
     binary: bin/metric-postgres-statsdb
-    goos:
-      - linux
-      - windows
-    goarch:
-      - amd64
-      - 386
-      - arm
-      - arm64
-    goarm:
-      - 5
-      - 6
-      - 7
     targets:
       - linux_386
       - linux_amd64
@@ -117,21 +69,9 @@ builds:
   - main: ./cmd/metric-postgres-statsio/main.go
     id: "metric-postgres-statsio"
     env:
-    - CGO_ENABLED=0
+      - CGO_ENABLED=0
     ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
     binary: bin/metric-postgres-statsio
-    goos:
-      - linux
-      - windows
-    goarch:
-      - amd64
-      - 386
-      - arm
-      - arm64
-    goarm:
-      - 5
-      - 6
-      - 7
     targets:
       - linux_386
       - linux_amd64
@@ -145,21 +85,9 @@ builds:
   - main: ./cmd/metric-postgres-statstable/main.go
     id: "metric-postgres-statstable"
     env:
-    - CGO_ENABLED=0
+      - CGO_ENABLED=0
     ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
     binary: bin/metric-postgres-statstable
-    goos:
-      - linux
-      - windows
-    goarch:
-      - amd64
-      - 386
-      - arm
-      - arm64
-    goarm:
-      - 5
-      - 6
-      - 7
     targets:
       - linux_386
       - linux_amd64
@@ -173,21 +101,9 @@ builds:
   - main: ./cmd/metric-postgres-graphite/main.go
     id: "metric-postgres-graphite"
     env:
-    - CGO_ENABLED=0
+      - CGO_ENABLED=0
     ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
     binary: bin/metric-postgres-graphite
-    goos:
-      - linux
-      - windows
-    goarch:
-      - amd64
-      - 386
-      - arm
-      - arm64
-    goarm:
-      - 5
-      - 6
-      - 7
     targets:
       - linux_386
       - linux_amd64
@@ -201,21 +117,9 @@ builds:
   - main: ./cmd/metric-postgres-relation-size/main.go
     id: "metric-postgres-relation-size"
     env:
-    - CGO_ENABLED=0
+      - CGO_ENABLED=0
     ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
     binary: bin/metric-postgres-relation-size
-    goos:
-      - linux
-      - windows
-    goarch:
-      - amd64
-      - 386
-      - arm
-      - arm64
-    goarm:
-      - 5
-      - 6
-      - 7
     targets:
       - linux_386
       - linux_amd64
@@ -229,21 +133,9 @@ builds:
   - main: ./cmd/metrics-postgres-query/main.go
     id: "metrics-postgres-query"
     env:
-    - CGO_ENABLED=0
+      - CGO_ENABLED=0
     ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
     binary: bin/metrics-postgres-query
-    goos:
-      - linux
-      - windows
-    goarch:
-      - amd64
-      - 386
-      - arm
-      - arm64
-    goarm:
-      - 5
-      - 6
-      - 7
     targets:
       - linux_386
       - linux_amd64

--- a/cmd/metric-postgres-graphite/main.go
+++ b/cmd/metric-postgres-graphite/main.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgpassfile"
+	"github.com/jackc/pgx/v5"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-plugin-sdk/sensu"
+	"nmollerup/sensu-check-postgres/internal/pgutil"
+)
+
+type Config struct {
+	sensu.PluginConfig
+	User       string
+	Password   string
+	IniFile    string
+	MasterHost string
+	SlaveHost  string
+	Port       int
+	Database   string
+	Sslmode    string
+	Scheme     string
+	Timeout    int
+}
+
+var (
+	plugin = Config{
+		PluginConfig: sensu.PluginConfig{
+			Name:     "metric-postgres-graphite",
+			Short:    "postgres replication lag metric",
+			Keyspace: "",
+		},
+	}
+
+	options = []sensu.ConfigOption{
+		&sensu.PluginConfigOption[string]{
+			Path:      "User",
+			Argument:  "user",
+			Shorthand: "u",
+			Usage:     "postgres user to connect",
+			Value:     &plugin.User,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "Password",
+			Argument:  "password",
+			Shorthand: "p",
+			Usage:     "Password for user",
+			Value:     &plugin.Password,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "pgpass file",
+			Argument:  "pgpass",
+			Shorthand: "f",
+			Usage:     "Location of .pgpass file for access to postgres",
+			Value:     &plugin.IniFile,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "master_host",
+			Argument:  "master-host",
+			Shorthand: "m",
+			Usage:     "PostgreSQL master host",
+			Value:     &plugin.MasterHost,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "slave_host",
+			Argument:  "slave-host",
+			Shorthand: "s",
+			Usage:     "PostgreSQL slave host",
+			Value:     &plugin.SlaveHost,
+			Default:   "localhost",
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "port",
+			Argument:  "port",
+			Shorthand: "P",
+			Usage:     "Port to connect to",
+			Value:     &plugin.Port,
+			Default:   5432,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "database",
+			Argument:  "database",
+			Shorthand: "d",
+			Usage:     "Database schema to connect to",
+			Value:     &plugin.Database,
+			Default:   "postgres",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "sslmode",
+			Argument:  "sslmode",
+			Shorthand: "S",
+			Usage:     "SSL mode for connecting to postgres",
+			Value:     &plugin.Sslmode,
+			Default:   "prefer",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "scheme",
+			Argument: "scheme",
+			Usage:    "Metric naming scheme",
+			Value:    &plugin.Scheme,
+			Default:  "postgresql.replication_lag",
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "timeout",
+			Argument:  "timeout",
+			Shorthand: "T",
+			Usage:     "Connection timeout (seconds)",
+			Value:     &plugin.Timeout,
+			Default:   10,
+		},
+	}
+)
+
+func main() {
+	metric := sensu.NewGoHandler(&plugin.PluginConfig, options, checkArgs, executeMetric)
+	metric.Execute()
+}
+
+func checkArgs(_ *corev2.Event) error {
+	if plugin.Port <= 1 || plugin.Port >= 65535 {
+		return fmt.Errorf("invalid port, should be a value between 1 and 65535")
+	}
+	if plugin.IniFile != "" {
+		if _, err := os.Stat(plugin.IniFile); os.IsNotExist(err) {
+			return fmt.Errorf("unable to open the supplied config file %s", plugin.IniFile)
+		}
+	}
+	if plugin.MasterHost == "" {
+		return fmt.Errorf("master-host is required")
+	}
+	return nil
+}
+
+func executeMetric(_ *corev2.Event) error {
+	ctx := context.Background()
+	timestamp := time.Now().Unix()
+
+	var dbUser, dbPass, dbDatabase string
+	var dbPort int
+	if plugin.IniFile != "" {
+		iniFile, err := pgpassfile.ReadPassfile(plugin.IniFile)
+		if err != nil {
+			return fmt.Errorf("error parsing ini file: %v", err)
+		}
+		for _, entry := range iniFile.Entries {
+			dbUser = entry.Username
+			dbPass = entry.Password
+			dbPort, _ = strconv.Atoi(entry.Port)
+			dbDatabase = entry.Database
+		}
+	} else {
+		dbUser = plugin.User
+		dbPass = plugin.Password
+		dbPort = plugin.Port
+		dbDatabase = plugin.Database
+	}
+
+	// Connect to master
+	masterDSN := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&connect_timeout=%d",
+		dbUser, dbPass, plugin.MasterHost, dbPort, dbDatabase, plugin.Sslmode, plugin.Timeout)
+	connMaster, err := pgx.Connect(ctx, masterDSN)
+	if err != nil {
+		return fmt.Errorf("error connecting to master postgres: %v", err)
+	}
+	defer func() {
+		_ = connMaster.Close(ctx)
+	}()
+
+	// Check PostgreSQL version
+	isPG9, err := pgutil.CheckVersionNewerThanPostgres9(ctx, connMaster)
+	if err != nil {
+		return fmt.Errorf("error checking postgres version: %v", err)
+	}
+
+	// Get master WAL position
+	var master string
+	var walQuery string
+	if isPG9 {
+		walQuery = "SELECT pg_current_xlog_location()"
+	} else {
+		walQuery = "SELECT pg_current_wal_lsn()"
+	}
+	err = connMaster.QueryRow(ctx, walQuery).Scan(&master)
+	if err != nil {
+		return fmt.Errorf("error querying master WAL position: %v", err)
+	}
+
+	// Get WAL segment size
+	var walSegmentSize string
+	err = connMaster.QueryRow(ctx, "SHOW wal_segment_size").Scan(&walSegmentSize)
+	if err != nil {
+		return fmt.Errorf("error querying wal_segment_size: %v", err)
+	}
+
+	re := regexp.MustCompile(`\d+`)
+	sizeStr := re.FindString(walSegmentSize)
+	if sizeStr == "" {
+		return fmt.Errorf("unable to parse wal_segment_size: %s", walSegmentSize)
+	}
+	segSize, _ := strconv.ParseInt(sizeStr, 10, 64)
+	segBytes := segSize << 20
+
+	_ = connMaster.Close(ctx)
+
+	// Connect to slave
+	slaveDSN := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&connect_timeout=%d",
+		dbUser, dbPass, plugin.SlaveHost, dbPort, dbDatabase, plugin.Sslmode, plugin.Timeout)
+	connSlave, err := pgx.Connect(ctx, slaveDSN)
+	if err != nil {
+		return fmt.Errorf("error connecting to slave postgres: %v", err)
+	}
+	defer func() {
+		_ = connSlave.Close(ctx)
+	}()
+
+	// Check slave PostgreSQL version
+	isPG9Slave, err := pgutil.CheckVersionNewerThanPostgres9(ctx, connSlave)
+	if err != nil {
+		return fmt.Errorf("error checking slave postgres version: %v", err)
+	}
+
+	// Get slave WAL position
+	var slave string
+	if isPG9Slave {
+		walQuery = "SELECT pg_last_xlog_receive_location()"
+	} else {
+		walQuery = "SELECT pg_last_wal_replay_lsn()"
+	}
+	err = connSlave.QueryRow(ctx, walQuery).Scan(&slave)
+	if err != nil {
+		return fmt.Errorf("error querying slave WAL position: %v", err)
+	}
+
+	_ = connSlave.Close(ctx)
+
+	// Compute lag
+	lag, err := pgutil.ComputeLag(master, slave, segBytes)
+	if err != nil {
+		return fmt.Errorf("error computing lag: %v", err)
+	}
+
+	if lag < 0 {
+		lag = -lag
+	}
+
+	fmt.Printf("%s %d %d\n", plugin.Scheme, lag, timestamp)
+
+	return nil
+}

--- a/cmd/metric-postgres-graphite/main_test.go
+++ b/cmd/metric-postgres-graphite/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckArgs(t *testing.T) {
+	origPort := plugin.Port
+	origIniFile := plugin.IniFile
+	origMasterHost := plugin.MasterHost
+	defer func() {
+		plugin.Port = origPort
+		plugin.IniFile = origIniFile
+		plugin.MasterHost = origMasterHost
+	}()
+
+	t.Run("valid with master host", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.MasterHost = "master.example.com"
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("missing master host", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.MasterHost = ""
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for missing master host")
+		}
+	})
+
+	t.Run("invalid port", func(t *testing.T) {
+		plugin.Port = 0
+		plugin.IniFile = ""
+		plugin.MasterHost = "master.example.com"
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for port 0")
+		}
+	})
+
+	t.Run("invalid port too high", func(t *testing.T) {
+		plugin.Port = 65535
+		plugin.IniFile = ""
+		plugin.MasterHost = "master.example.com"
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for port 65535")
+		}
+	})
+
+	t.Run("valid ini file", func(t *testing.T) {
+		tmpFile := filepath.Join(t.TempDir(), "pgpass")
+		if err := os.WriteFile(tmpFile, []byte("localhost:5432:*:user:pass"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		plugin.Port = 5432
+		plugin.IniFile = tmpFile
+		plugin.MasterHost = "master.example.com"
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("nonexistent ini file", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = "/nonexistent/path/pgpass"
+		plugin.MasterHost = "master.example.com"
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for nonexistent ini file")
+		}
+	})
+}

--- a/cmd/metric-postgres-relation-size/main.go
+++ b/cmd/metric-postgres-relation-size/main.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgpassfile"
+	"github.com/jackc/pgx/v5"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-plugin-sdk/sensu"
+)
+
+type Config struct {
+	sensu.PluginConfig
+	User     string
+	Password string
+	IniFile  string
+	Hostname string
+	Port     int
+	Database string
+	Sslmode  string
+	Scheme   string
+	Timeout  int
+	Limit    int
+}
+
+var (
+	plugin = Config{
+		PluginConfig: sensu.PluginConfig{
+			Name:     "metric-postgres-relation-size",
+			Short:    "postgres relation size metric",
+			Keyspace: "",
+		},
+	}
+
+	options = []sensu.ConfigOption{
+		&sensu.PluginConfigOption[string]{
+			Path:      "User",
+			Argument:  "user",
+			Shorthand: "u",
+			Usage:     "postgres user to connect",
+			Value:     &plugin.User,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "Password",
+			Argument:  "password",
+			Shorthand: "p",
+			Usage:     "Password for user",
+			Value:     &plugin.Password,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "pgpass file",
+			Argument:  "pgpass",
+			Shorthand: "f",
+			Usage:     "Location of .pgpass file for access to postgres",
+			Value:     &plugin.IniFile,
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "port",
+			Argument:  "port",
+			Shorthand: "P",
+			Usage:     "Port to connect to",
+			Value:     &plugin.Port,
+			Default:   5432,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "hostname",
+			Argument: "hostname",
+			Usage:    "Hostname to login to",
+			Value:    &plugin.Hostname,
+			Default:  "localhost",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "database",
+			Argument:  "database",
+			Shorthand: "d",
+			Usage:     "Database name",
+			Value:     &plugin.Database,
+			Default:   "postgres",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "sslmode",
+			Argument:  "sslmode",
+			Shorthand: "s",
+			Usage:     "SSL mode for connecting to postgres",
+			Value:     &plugin.Sslmode,
+			Default:   "prefer",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "scheme",
+			Argument: "scheme",
+			Usage:    "Metric naming scheme",
+			Value:    &plugin.Scheme,
+			Default:  "postgresql",
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "timeout",
+			Argument:  "timeout",
+			Shorthand: "T",
+			Usage:     "Connection timeout (seconds)",
+			Value:     &plugin.Timeout,
+			Default:   10,
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "limit",
+			Argument:  "limit",
+			Shorthand: "l",
+			Usage:     "Limit query to this many results",
+			Value:     &plugin.Limit,
+			Default:   25,
+		},
+	}
+)
+
+func main() {
+	metric := sensu.NewGoHandler(&plugin.PluginConfig, options, checkArgs, executeMetric)
+	metric.Execute()
+}
+
+func checkArgs(_ *corev2.Event) error {
+	if plugin.Port <= 1 || plugin.Port >= 65535 {
+		return fmt.Errorf("invalid port, should be a value between 1 and 65535")
+	}
+	if plugin.IniFile != "" {
+		if _, err := os.Stat(plugin.IniFile); os.IsNotExist(err) {
+			return fmt.Errorf("unable to open the supplied config file %s", plugin.IniFile)
+		}
+	}
+	if plugin.Limit <= 0 {
+		return fmt.Errorf("limit must be a positive integer")
+	}
+	return nil
+}
+
+func executeMetric(_ *corev2.Event) error {
+	ctx := context.Background()
+	timestamp := time.Now().Unix()
+
+	var dbUser, dbPass, dbHost, dbDatabase string
+	var dbPort int
+	if plugin.IniFile != "" {
+		iniFile, err := pgpassfile.ReadPassfile(plugin.IniFile)
+		if err != nil {
+			return fmt.Errorf("error parsing ini file: %v", err)
+		}
+		for _, entry := range iniFile.Entries {
+			dbUser = entry.Username
+			dbPass = entry.Password
+			dbHost = entry.Hostname
+			dbPort, _ = strconv.Atoi(entry.Port)
+			dbDatabase = entry.Database
+		}
+	} else {
+		dbUser = plugin.User
+		dbPass = plugin.Password
+		dbHost = plugin.Hostname
+		dbPort = plugin.Port
+		dbDatabase = plugin.Database
+	}
+
+	dataSourceName := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&connect_timeout=%d",
+		dbUser, dbPass, dbHost, dbPort, dbDatabase, plugin.Sslmode, plugin.Timeout)
+	db, err := pgx.Connect(ctx, dataSourceName)
+	if err != nil {
+		return fmt.Errorf("error connecting to postgres: %v", err)
+	}
+	defer func() {
+		_ = db.Close(ctx)
+	}()
+
+	query := `SELECT nspname || '.' || relname AS relation,
+		pg_total_relation_size(C.oid) AS total_size
+		FROM pg_class C
+		LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace)
+		WHERE nspname NOT IN ('pg_catalog', 'information_schema')
+		ORDER BY pg_total_relation_size(C.oid) DESC
+		LIMIT $1`
+
+	rows, err := db.Query(ctx, query, plugin.Limit)
+	if err != nil {
+		return fmt.Errorf("error querying relation sizes: %v", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var relation string
+		var totalSize int64
+		err = rows.Scan(&relation, &totalSize)
+		if err != nil {
+			return fmt.Errorf("error scanning row: %v", err)
+		}
+		fmt.Printf("%s.size.%s.%s %d %d\n", plugin.Scheme, dbDatabase, relation, totalSize, timestamp)
+	}
+
+	return nil
+}

--- a/cmd/metric-postgres-relation-size/main_test.go
+++ b/cmd/metric-postgres-relation-size/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckArgs(t *testing.T) {
+	origPort := plugin.Port
+	origIniFile := plugin.IniFile
+	origLimit := plugin.Limit
+	defer func() {
+		plugin.Port = origPort
+		plugin.IniFile = origIniFile
+		plugin.Limit = origLimit
+	}()
+
+	t.Run("valid defaults", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.Limit = 25
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("valid limit 1", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.Limit = 1
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid limit zero", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.Limit = 0
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for limit 0")
+		}
+	})
+
+	t.Run("invalid limit negative", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.Limit = -5
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for negative limit")
+		}
+	})
+
+	t.Run("invalid port", func(t *testing.T) {
+		plugin.Port = 0
+		plugin.IniFile = ""
+		plugin.Limit = 25
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for port 0")
+		}
+	})
+
+	t.Run("valid ini file", func(t *testing.T) {
+		tmpFile := filepath.Join(t.TempDir(), "pgpass")
+		if err := os.WriteFile(tmpFile, []byte("localhost:5432:*:user:pass"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		plugin.Port = 5432
+		plugin.IniFile = tmpFile
+		plugin.Limit = 25
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("nonexistent ini file", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = "/nonexistent/path/pgpass"
+		plugin.Limit = 25
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for nonexistent ini file")
+		}
+	})
+}

--- a/cmd/metric-postgres-statsbgwriter/main.go
+++ b/cmd/metric-postgres-statsbgwriter/main.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgpassfile"
+	"github.com/jackc/pgx/v5"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-plugin-sdk/sensu"
+)
+
+type Config struct {
+	sensu.PluginConfig
+	User     string
+	Password string
+	IniFile  string
+	Hostname string
+	Port     int
+	Database string
+	Sslmode  string
+	Scheme   string
+	Timeout  int
+}
+
+var (
+	plugin = Config{
+		PluginConfig: sensu.PluginConfig{
+			Name:     "metric-postgres-statsbgwriter",
+			Short:    "postgres bgwriter metric",
+			Keyspace: "",
+		},
+	}
+
+	options = []sensu.ConfigOption{
+		&sensu.PluginConfigOption[string]{
+			Path:      "User",
+			Argument:  "user",
+			Shorthand: "u",
+			Usage:     "postgres user to connect",
+			Value:     &plugin.User,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "Password",
+			Argument:  "password",
+			Shorthand: "p",
+			Usage:     "Password for user",
+			Value:     &plugin.Password,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "pgpass file",
+			Argument:  "pgpass",
+			Shorthand: "f",
+			Usage:     "Location of .pgpass file for access to postgres",
+			Value:     &plugin.IniFile,
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "port",
+			Argument:  "port",
+			Shorthand: "P",
+			Usage:     "Port to connect to",
+			Value:     &plugin.Port,
+			Default:   5432,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "hostname",
+			Argument: "hostname",
+			Usage:    "Hostname to login to",
+			Value:    &plugin.Hostname,
+			Default:  "localhost",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "database",
+			Argument:  "database",
+			Shorthand: "d",
+			Usage:     "Database schema to connect to",
+			Value:     &plugin.Database,
+			Default:   "postgres",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "sslmode",
+			Argument:  "sslmode",
+			Shorthand: "s",
+			Usage:     "SSL mode for connecting to postgres",
+			Value:     &plugin.Sslmode,
+			Default:   "prefer",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "scheme",
+			Argument: "scheme",
+			Usage:    "Metric naming scheme",
+			Value:    &plugin.Scheme,
+			Default:  "postgresql",
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "timeout",
+			Argument:  "timeout",
+			Shorthand: "T",
+			Usage:     "Connection timeout (seconds)",
+			Value:     &plugin.Timeout,
+			Default:   10,
+		},
+	}
+)
+
+func main() {
+	metric := sensu.NewGoHandler(&plugin.PluginConfig, options, checkArgs, executeMetric)
+	metric.Execute()
+}
+
+func checkArgs(_ *corev2.Event) error {
+	if plugin.Port <= 1 || plugin.Port >= 65535 {
+		return fmt.Errorf("invalid port, should be a value between 1 and 65535")
+	}
+	if plugin.IniFile != "" {
+		if _, err := os.Stat(plugin.IniFile); os.IsNotExist(err) {
+			return fmt.Errorf("unable to open the supplied config file %s", plugin.IniFile)
+		}
+	}
+	return nil
+}
+
+func executeMetric(_ *corev2.Event) error {
+	ctx := context.Background()
+	timestamp := time.Now().Unix()
+
+	var dbUser, dbPass, dbHost, dbDatabase string
+	var dbPort int
+	if plugin.IniFile != "" {
+		iniFile, err := pgpassfile.ReadPassfile(plugin.IniFile)
+		if err != nil {
+			return fmt.Errorf("error parsing ini file: %v", err)
+		}
+		for _, entry := range iniFile.Entries {
+			dbUser = entry.Username
+			dbPass = entry.Password
+			dbHost = entry.Hostname
+			dbPort, _ = strconv.Atoi(entry.Port)
+			dbDatabase = entry.Database
+		}
+	} else {
+		dbUser = plugin.User
+		dbPass = plugin.Password
+		dbHost = plugin.Hostname
+		dbPort = plugin.Port
+		dbDatabase = plugin.Database
+	}
+
+	dataSourceName := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&connect_timeout=%d",
+		dbUser, dbPass, dbHost, dbPort, dbDatabase, plugin.Sslmode, plugin.Timeout)
+	db, err := pgx.Connect(ctx, dataSourceName)
+	if err != nil {
+		return fmt.Errorf("error connecting to postgres: %v", err)
+	}
+	defer func() {
+		_ = db.Close(ctx)
+	}()
+
+	query := `SELECT checkpoints_timed, checkpoints_req,
+		checkpoint_write_time, checkpoint_sync_time,
+		buffers_checkpoint, buffers_clean,
+		maxwritten_clean, buffers_backend, buffers_backend_fsync,
+		buffers_alloc
+		FROM pg_stat_bgwriter`
+
+	var checkpointsTimed, checkpointsReq int64
+	var checkpointWriteTime, checkpointSyncTime float64
+	var buffersCheckpoint, buffersClean, maxwrittenClean int64
+	var buffersBackend, buffersBackendFsync, buffersAlloc int64
+
+	err = db.QueryRow(ctx, query).Scan(
+		&checkpointsTimed, &checkpointsReq,
+		&checkpointWriteTime, &checkpointSyncTime,
+		&buffersCheckpoint, &buffersClean,
+		&maxwrittenClean, &buffersBackend, &buffersBackendFsync,
+		&buffersAlloc,
+	)
+	if err != nil {
+		return fmt.Errorf("error querying bgwriter stats: %v", err)
+	}
+
+	fmt.Printf("%s.bgwriter.checkpoints_timed %d %d\n", plugin.Scheme, checkpointsTimed, timestamp)
+	fmt.Printf("%s.bgwriter.checkpoints_req %d %d\n", plugin.Scheme, checkpointsReq, timestamp)
+	fmt.Printf("%s.bgwriter.checkpoints_write_time %g %d\n", plugin.Scheme, checkpointWriteTime, timestamp)
+	fmt.Printf("%s.bgwriter.checkpoints_sync_time %g %d\n", plugin.Scheme, checkpointSyncTime, timestamp)
+	fmt.Printf("%s.bgwriter.buffers_checkpoint %d %d\n", plugin.Scheme, buffersCheckpoint, timestamp)
+	fmt.Printf("%s.bgwriter.buffers_clean %d %d\n", plugin.Scheme, buffersClean, timestamp)
+	fmt.Printf("%s.bgwriter.maxwritten_clean %d %d\n", plugin.Scheme, maxwrittenClean, timestamp)
+	fmt.Printf("%s.bgwriter.buffers_backend %d %d\n", plugin.Scheme, buffersBackend, timestamp)
+	fmt.Printf("%s.bgwriter.buffers_backend_fsync %d %d\n", plugin.Scheme, buffersBackendFsync, timestamp)
+	fmt.Printf("%s.bgwriter.buffers_alloc %d %d\n", plugin.Scheme, buffersAlloc, timestamp)
+
+	return nil
+}

--- a/cmd/metric-postgres-statsbgwriter/main_test.go
+++ b/cmd/metric-postgres-statsbgwriter/main_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckArgs(t *testing.T) {
+	// Save and restore original plugin state
+	origPort := plugin.Port
+	origIniFile := plugin.IniFile
+	defer func() {
+		plugin.Port = origPort
+		plugin.IniFile = origIniFile
+	}()
+
+	t.Run("valid defaults", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid port too low", func(t *testing.T) {
+		plugin.Port = 0
+		plugin.IniFile = ""
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for port 0")
+		}
+	})
+
+	t.Run("invalid port too high", func(t *testing.T) {
+		plugin.Port = 65535
+		plugin.IniFile = ""
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for port 65535")
+		}
+	})
+
+	t.Run("valid ini file", func(t *testing.T) {
+		tmpFile := filepath.Join(t.TempDir(), "pgpass")
+		if err := os.WriteFile(tmpFile, []byte("localhost:5432:*:user:pass"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		plugin.Port = 5432
+		plugin.IniFile = tmpFile
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("nonexistent ini file", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = "/nonexistent/path/pgpass"
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for nonexistent ini file")
+		}
+	})
+}

--- a/cmd/metric-postgres-statsdb/main.go
+++ b/cmd/metric-postgres-statsdb/main.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgpassfile"
+	"github.com/jackc/pgx/v5"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-plugin-sdk/sensu"
+)
+
+type Config struct {
+	sensu.PluginConfig
+	User         string
+	Password     string
+	IniFile      string
+	Hostname     string
+	Port         int
+	Database     string
+	Sslmode      string
+	Scheme       string
+	Timeout      int
+	AllDatabases bool
+}
+
+var (
+	plugin = Config{
+		PluginConfig: sensu.PluginConfig{
+			Name:     "metric-postgres-statsdb",
+			Short:    "postgres database stats metric",
+			Keyspace: "",
+		},
+	}
+
+	options = []sensu.ConfigOption{
+		&sensu.PluginConfigOption[string]{
+			Path:      "User",
+			Argument:  "user",
+			Shorthand: "u",
+			Usage:     "postgres user to connect",
+			Value:     &plugin.User,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "Password",
+			Argument:  "password",
+			Shorthand: "p",
+			Usage:     "Password for user",
+			Value:     &plugin.Password,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "pgpass file",
+			Argument:  "pgpass",
+			Shorthand: "f",
+			Usage:     "Location of .pgpass file for access to postgres",
+			Value:     &plugin.IniFile,
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "port",
+			Argument:  "port",
+			Shorthand: "P",
+			Usage:     "Port to connect to",
+			Value:     &plugin.Port,
+			Default:   5432,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "hostname",
+			Argument: "hostname",
+			Usage:    "Hostname to login to",
+			Value:    &plugin.Hostname,
+			Default:  "localhost",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "database",
+			Argument:  "database",
+			Shorthand: "d",
+			Usage:     "Database schema to connect to",
+			Value:     &plugin.Database,
+			Default:   "postgres",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "sslmode",
+			Argument:  "sslmode",
+			Shorthand: "s",
+			Usage:     "SSL mode for connecting to postgres",
+			Value:     &plugin.Sslmode,
+			Default:   "prefer",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "scheme",
+			Argument: "scheme",
+			Usage:    "Metric naming scheme",
+			Value:    &plugin.Scheme,
+			Default:  "postgresql",
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "timeout",
+			Argument:  "timeout",
+			Shorthand: "T",
+			Usage:     "Connection timeout (seconds)",
+			Value:     &plugin.Timeout,
+			Default:   10,
+		},
+		&sensu.PluginConfigOption[bool]{
+			Path:      "all-databases",
+			Argument:  "all-databases",
+			Shorthand: "a",
+			Usage:     "Get stats for all available databases",
+			Value:     &plugin.AllDatabases,
+			Default:   false,
+		},
+	}
+)
+
+func main() {
+	metric := sensu.NewGoHandler(&plugin.PluginConfig, options, checkArgs, executeMetric)
+	metric.Execute()
+}
+
+func checkArgs(_ *corev2.Event) error {
+	if plugin.Port <= 1 || plugin.Port >= 65535 {
+		return fmt.Errorf("invalid port, should be a value between 1 and 65535")
+	}
+	if plugin.IniFile != "" {
+		if _, err := os.Stat(plugin.IniFile); os.IsNotExist(err) {
+			return fmt.Errorf("unable to open the supplied config file %s", plugin.IniFile)
+		}
+	}
+	return nil
+}
+
+func executeMetric(_ *corev2.Event) error {
+	ctx := context.Background()
+	timestamp := time.Now().Unix()
+
+	var dbUser, dbPass, dbHost, dbDatabase string
+	var dbPort int
+	if plugin.IniFile != "" {
+		iniFile, err := pgpassfile.ReadPassfile(plugin.IniFile)
+		if err != nil {
+			return fmt.Errorf("error parsing ini file: %v", err)
+		}
+		for _, entry := range iniFile.Entries {
+			dbUser = entry.Username
+			dbPass = entry.Password
+			dbHost = entry.Hostname
+			dbPort, _ = strconv.Atoi(entry.Port)
+			dbDatabase = entry.Database
+		}
+	} else {
+		dbUser = plugin.User
+		dbPass = plugin.Password
+		dbHost = plugin.Hostname
+		dbPort = plugin.Port
+		dbDatabase = plugin.Database
+	}
+
+	dataSourceName := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&connect_timeout=%d",
+		dbUser, dbPass, dbHost, dbPort, dbDatabase, plugin.Sslmode, plugin.Timeout)
+	db, err := pgx.Connect(ctx, dataSourceName)
+	if err != nil {
+		return fmt.Errorf("error connecting to postgres: %v", err)
+	}
+	defer func() {
+		_ = db.Close(ctx)
+	}()
+
+	query := "SELECT * FROM pg_stat_database"
+	var rows pgx.Rows
+	if plugin.AllDatabases {
+		rows, err = db.Query(ctx, query)
+	} else {
+		query += " WHERE datname = $1"
+		rows, err = db.Query(ctx, query, dbDatabase)
+	}
+	if err != nil {
+		return fmt.Errorf("error querying database stats: %v", err)
+	}
+	defer rows.Close()
+
+	skipColumns := map[string]bool{
+		"datid":       true,
+		"datname":     true,
+		"stats_reset": true,
+	}
+
+	fieldDescs := rows.FieldDescriptions()
+
+	for rows.Next() {
+		values, err := rows.Values()
+		if err != nil {
+			return fmt.Errorf("error scanning row: %v", err)
+		}
+
+		// Find datname column index
+		var database string
+		for i, fd := range fieldDescs {
+			if string(fd.Name) == "datname" {
+				if values[i] != nil {
+					database = fmt.Sprintf("%v", values[i])
+				}
+				break
+			}
+		}
+
+		if database == "" {
+			continue
+		}
+
+		for i, fd := range fieldDescs {
+			colName := string(fd.Name)
+			if skipColumns[colName] {
+				continue
+			}
+			if values[i] != nil {
+				fmt.Printf("%s.statsdb.%s.%s %v %d\n", plugin.Scheme, database, colName, values[i], timestamp)
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/metric-postgres-statsdb/main_test.go
+++ b/cmd/metric-postgres-statsdb/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckArgs(t *testing.T) {
+	origPort := plugin.Port
+	origIniFile := plugin.IniFile
+	defer func() {
+		plugin.Port = origPort
+		plugin.IniFile = origIniFile
+	}()
+
+	t.Run("valid defaults", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid port too low", func(t *testing.T) {
+		plugin.Port = 0
+		plugin.IniFile = ""
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for port 0")
+		}
+	})
+
+	t.Run("invalid port too high", func(t *testing.T) {
+		plugin.Port = 65535
+		plugin.IniFile = ""
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for port 65535")
+		}
+	})
+
+	t.Run("valid ini file", func(t *testing.T) {
+		tmpFile := filepath.Join(t.TempDir(), "pgpass")
+		if err := os.WriteFile(tmpFile, []byte("localhost:5432:*:user:pass"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		plugin.Port = 5432
+		plugin.IniFile = tmpFile
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("nonexistent ini file", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = "/nonexistent/path/pgpass"
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for nonexistent ini file")
+		}
+	})
+}

--- a/cmd/metric-postgres-statsio/main.go
+++ b/cmd/metric-postgres-statsio/main.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgpassfile"
+	"github.com/jackc/pgx/v5"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-plugin-sdk/sensu"
+)
+
+type Config struct {
+	sensu.PluginConfig
+	User     string
+	Password string
+	IniFile  string
+	Hostname string
+	Port     int
+	Database string
+	Sslmode  string
+	Scheme   string
+	Timeout  int
+	Scope    string
+}
+
+var (
+	plugin = Config{
+		PluginConfig: sensu.PluginConfig{
+			Name:     "metric-postgres-statsio",
+			Short:    "postgres I/O stats metric",
+			Keyspace: "",
+		},
+	}
+
+	options = []sensu.ConfigOption{
+		&sensu.PluginConfigOption[string]{
+			Path:      "User",
+			Argument:  "user",
+			Shorthand: "u",
+			Usage:     "postgres user to connect",
+			Value:     &plugin.User,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "Password",
+			Argument:  "password",
+			Shorthand: "p",
+			Usage:     "Password for user",
+			Value:     &plugin.Password,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "pgpass file",
+			Argument:  "pgpass",
+			Shorthand: "f",
+			Usage:     "Location of .pgpass file for access to postgres",
+			Value:     &plugin.IniFile,
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "port",
+			Argument:  "port",
+			Shorthand: "P",
+			Usage:     "Port to connect to",
+			Value:     &plugin.Port,
+			Default:   5432,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "hostname",
+			Argument: "hostname",
+			Usage:    "Hostname to login to",
+			Value:    &plugin.Hostname,
+			Default:  "localhost",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "database",
+			Argument:  "database",
+			Shorthand: "d",
+			Usage:     "Database name",
+			Value:     &plugin.Database,
+			Default:   "postgres",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "sslmode",
+			Argument:  "sslmode",
+			Shorthand: "s",
+			Usage:     "SSL mode for connecting to postgres",
+			Value:     &plugin.Sslmode,
+			Default:   "prefer",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "scheme",
+			Argument: "scheme",
+			Usage:    "Metric naming scheme",
+			Value:    &plugin.Scheme,
+			Default:  "postgresql",
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "timeout",
+			Argument:  "timeout",
+			Shorthand: "T",
+			Usage:     "Connection timeout (seconds)",
+			Value:     &plugin.Timeout,
+			Default:   10,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "scope",
+			Argument: "scope",
+			Usage:    "Stats scope (user or all)",
+			Value:    &plugin.Scope,
+			Default:  "user",
+		},
+	}
+)
+
+func main() {
+	metric := sensu.NewGoHandler(&plugin.PluginConfig, options, checkArgs, executeMetric)
+	metric.Execute()
+}
+
+func checkArgs(_ *corev2.Event) error {
+	if plugin.Port <= 1 || plugin.Port >= 65535 {
+		return fmt.Errorf("invalid port, should be a value between 1 and 65535")
+	}
+	if plugin.IniFile != "" {
+		if _, err := os.Stat(plugin.IniFile); os.IsNotExist(err) {
+			return fmt.Errorf("unable to open the supplied config file %s", plugin.IniFile)
+		}
+	}
+	if plugin.Scope != "user" && plugin.Scope != "all" {
+		return fmt.Errorf("scope must be 'user' or 'all'")
+	}
+	return nil
+}
+
+func executeMetric(_ *corev2.Event) error {
+	ctx := context.Background()
+	timestamp := time.Now().Unix()
+
+	var dbUser, dbPass, dbHost, dbDatabase string
+	var dbPort int
+	if plugin.IniFile != "" {
+		iniFile, err := pgpassfile.ReadPassfile(plugin.IniFile)
+		if err != nil {
+			return fmt.Errorf("error parsing ini file: %v", err)
+		}
+		for _, entry := range iniFile.Entries {
+			dbUser = entry.Username
+			dbPass = entry.Password
+			dbHost = entry.Hostname
+			dbPort, _ = strconv.Atoi(entry.Port)
+			dbDatabase = entry.Database
+		}
+	} else {
+		dbUser = plugin.User
+		dbPass = plugin.Password
+		dbHost = plugin.Hostname
+		dbPort = plugin.Port
+		dbDatabase = plugin.Database
+	}
+
+	dataSourceName := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&connect_timeout=%d",
+		dbUser, dbPass, dbHost, dbPort, dbDatabase, plugin.Sslmode, plugin.Timeout)
+	db, err := pgx.Connect(ctx, dataSourceName)
+	if err != nil {
+		return fmt.Errorf("error connecting to postgres: %v", err)
+	}
+	defer func() {
+		_ = db.Close(ctx)
+	}()
+
+	query := fmt.Sprintf(`SELECT
+		sum(heap_blks_read) AS heap_blks_read, sum(heap_blks_hit) AS heap_blks_hit,
+		sum(idx_blks_read) AS idx_blks_read, sum(idx_blks_hit) AS idx_blks_hit,
+		sum(toast_blks_read) AS toast_blks_read, sum(toast_blks_hit) AS toast_blks_hit,
+		sum(tidx_blks_read) AS tidx_blks_read, sum(tidx_blks_hit) AS tidx_blks_hit
+		FROM pg_statio_%s_tables`, plugin.Scope)
+
+	var heapBlksRead, heapBlksHit, idxBlksRead, idxBlksHit int64
+	var toastBlksRead, toastBlksHit, tidxBlksRead, tidxBlksHit int64
+
+	err = db.QueryRow(ctx, query).Scan(
+		&heapBlksRead, &heapBlksHit,
+		&idxBlksRead, &idxBlksHit,
+		&toastBlksRead, &toastBlksHit,
+		&tidxBlksRead, &tidxBlksHit,
+	)
+	if err != nil {
+		return fmt.Errorf("error querying statsio: %v", err)
+	}
+
+	fmt.Printf("%s.statsio.%s.heap_blks_read %d %d\n", plugin.Scheme, dbDatabase, heapBlksRead, timestamp)
+	fmt.Printf("%s.statsio.%s.heap_blks_hit %d %d\n", plugin.Scheme, dbDatabase, heapBlksHit, timestamp)
+	fmt.Printf("%s.statsio.%s.idx_blks_read %d %d\n", plugin.Scheme, dbDatabase, idxBlksRead, timestamp)
+	fmt.Printf("%s.statsio.%s.idx_blks_hit %d %d\n", plugin.Scheme, dbDatabase, idxBlksHit, timestamp)
+	fmt.Printf("%s.statsio.%s.toast_blks_read %d %d\n", plugin.Scheme, dbDatabase, toastBlksRead, timestamp)
+	fmt.Printf("%s.statsio.%s.toast_blks_hit %d %d\n", plugin.Scheme, dbDatabase, toastBlksHit, timestamp)
+	fmt.Printf("%s.statsio.%s.tidx_blks_read %d %d\n", plugin.Scheme, dbDatabase, tidxBlksRead, timestamp)
+	fmt.Printf("%s.statsio.%s.tidx_blks_hit %d %d\n", plugin.Scheme, dbDatabase, tidxBlksHit, timestamp)
+
+	return nil
+}

--- a/cmd/metric-postgres-statsio/main_test.go
+++ b/cmd/metric-postgres-statsio/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckArgs(t *testing.T) {
+	origPort := plugin.Port
+	origIniFile := plugin.IniFile
+	origScope := plugin.Scope
+	defer func() {
+		plugin.Port = origPort
+		plugin.IniFile = origIniFile
+		plugin.Scope = origScope
+	}()
+
+	t.Run("valid defaults", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.Scope = "user"
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("valid scope all", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.Scope = "all"
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid scope", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.Scope = "invalid"
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for invalid scope")
+		}
+	})
+
+	t.Run("empty scope", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.Scope = ""
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for empty scope")
+		}
+	})
+
+	t.Run("invalid port", func(t *testing.T) {
+		plugin.Port = 0
+		plugin.IniFile = ""
+		plugin.Scope = "user"
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for port 0")
+		}
+	})
+
+	t.Run("valid ini file", func(t *testing.T) {
+		tmpFile := filepath.Join(t.TempDir(), "pgpass")
+		if err := os.WriteFile(tmpFile, []byte("localhost:5432:*:user:pass"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		plugin.Port = 5432
+		plugin.IniFile = tmpFile
+		plugin.Scope = "user"
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("nonexistent ini file", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = "/nonexistent/path/pgpass"
+		plugin.Scope = "user"
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for nonexistent ini file")
+		}
+	})
+}

--- a/cmd/metric-postgres-statstable/main.go
+++ b/cmd/metric-postgres-statstable/main.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgpassfile"
+	"github.com/jackc/pgx/v5"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-plugin-sdk/sensu"
+)
+
+type Config struct {
+	sensu.PluginConfig
+	User     string
+	Password string
+	IniFile  string
+	Hostname string
+	Port     int
+	Database string
+	Sslmode  string
+	Scheme   string
+	Timeout  int
+	Scope    string
+}
+
+var (
+	plugin = Config{
+		PluginConfig: sensu.PluginConfig{
+			Name:     "metric-postgres-statstable",
+			Short:    "postgres table stats metric",
+			Keyspace: "",
+		},
+	}
+
+	options = []sensu.ConfigOption{
+		&sensu.PluginConfigOption[string]{
+			Path:      "User",
+			Argument:  "user",
+			Shorthand: "u",
+			Usage:     "postgres user to connect",
+			Value:     &plugin.User,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "Password",
+			Argument:  "password",
+			Shorthand: "p",
+			Usage:     "Password for user",
+			Value:     &plugin.Password,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "pgpass file",
+			Argument:  "pgpass",
+			Shorthand: "f",
+			Usage:     "Location of .pgpass file for access to postgres",
+			Value:     &plugin.IniFile,
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "port",
+			Argument:  "port",
+			Shorthand: "P",
+			Usage:     "Port to connect to",
+			Value:     &plugin.Port,
+			Default:   5432,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "hostname",
+			Argument: "hostname",
+			Usage:    "Hostname to login to",
+			Value:    &plugin.Hostname,
+			Default:  "localhost",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "database",
+			Argument:  "database",
+			Shorthand: "d",
+			Usage:     "Database name",
+			Value:     &plugin.Database,
+			Default:   "postgres",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "sslmode",
+			Argument:  "sslmode",
+			Shorthand: "s",
+			Usage:     "SSL mode for connecting to postgres",
+			Value:     &plugin.Sslmode,
+			Default:   "prefer",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "scheme",
+			Argument: "scheme",
+			Usage:    "Metric naming scheme",
+			Value:    &plugin.Scheme,
+			Default:  "postgresql",
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "timeout",
+			Argument:  "timeout",
+			Shorthand: "T",
+			Usage:     "Connection timeout (seconds)",
+			Value:     &plugin.Timeout,
+			Default:   10,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "scope",
+			Argument: "scope",
+			Usage:    "Stats scope (user or all)",
+			Value:    &plugin.Scope,
+			Default:  "user",
+		},
+	}
+)
+
+func main() {
+	metric := sensu.NewGoHandler(&plugin.PluginConfig, options, checkArgs, executeMetric)
+	metric.Execute()
+}
+
+func checkArgs(_ *corev2.Event) error {
+	if plugin.Port <= 1 || plugin.Port >= 65535 {
+		return fmt.Errorf("invalid port, should be a value between 1 and 65535")
+	}
+	if plugin.IniFile != "" {
+		if _, err := os.Stat(plugin.IniFile); os.IsNotExist(err) {
+			return fmt.Errorf("unable to open the supplied config file %s", plugin.IniFile)
+		}
+	}
+	if plugin.Scope != "user" && plugin.Scope != "all" {
+		return fmt.Errorf("scope must be 'user' or 'all'")
+	}
+	return nil
+}
+
+func executeMetric(_ *corev2.Event) error {
+	ctx := context.Background()
+	timestamp := time.Now().Unix()
+
+	var dbUser, dbPass, dbHost, dbDatabase string
+	var dbPort int
+	if plugin.IniFile != "" {
+		iniFile, err := pgpassfile.ReadPassfile(plugin.IniFile)
+		if err != nil {
+			return fmt.Errorf("error parsing ini file: %v", err)
+		}
+		for _, entry := range iniFile.Entries {
+			dbUser = entry.Username
+			dbPass = entry.Password
+			dbHost = entry.Hostname
+			dbPort, _ = strconv.Atoi(entry.Port)
+			dbDatabase = entry.Database
+		}
+	} else {
+		dbUser = plugin.User
+		dbPass = plugin.Password
+		dbHost = plugin.Hostname
+		dbPort = plugin.Port
+		dbDatabase = plugin.Database
+	}
+
+	dataSourceName := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&connect_timeout=%d",
+		dbUser, dbPass, dbHost, dbPort, dbDatabase, plugin.Sslmode, plugin.Timeout)
+	db, err := pgx.Connect(ctx, dataSourceName)
+	if err != nil {
+		return fmt.Errorf("error connecting to postgres: %v", err)
+	}
+	defer func() {
+		_ = db.Close(ctx)
+	}()
+
+	query := fmt.Sprintf(`SELECT
+		sum(seq_scan) AS seq_scan, sum(seq_tup_read) AS seq_tup_read,
+		sum(idx_scan) AS idx_scan, sum(idx_tup_fetch) AS idx_tup_fetch,
+		sum(n_tup_ins) AS n_tup_ins, sum(n_tup_upd) AS n_tup_upd, sum(n_tup_del) AS n_tup_del,
+		sum(n_tup_hot_upd) AS n_tup_hot_upd, sum(n_live_tup) AS n_live_tup, sum(n_dead_tup) AS n_dead_tup
+		FROM pg_stat_%s_tables`, plugin.Scope)
+
+	var seqScan, seqTupRead, idxScan, idxTupFetch int64
+	var nTupIns, nTupUpd, nTupDel, nTupHotUpd int64
+	var nLiveTup, nDeadTup int64
+
+	err = db.QueryRow(ctx, query).Scan(
+		&seqScan, &seqTupRead,
+		&idxScan, &idxTupFetch,
+		&nTupIns, &nTupUpd, &nTupDel,
+		&nTupHotUpd, &nLiveTup, &nDeadTup,
+	)
+	if err != nil {
+		return fmt.Errorf("error querying statstable: %v", err)
+	}
+
+	fmt.Printf("%s.statstable.%s.seq_scan %d %d\n", plugin.Scheme, dbDatabase, seqScan, timestamp)
+	fmt.Printf("%s.statstable.%s.seq_tup_read %d %d\n", plugin.Scheme, dbDatabase, seqTupRead, timestamp)
+	fmt.Printf("%s.statstable.%s.idx_scan %d %d\n", plugin.Scheme, dbDatabase, idxScan, timestamp)
+	fmt.Printf("%s.statstable.%s.idx_tup_fetch %d %d\n", plugin.Scheme, dbDatabase, idxTupFetch, timestamp)
+	fmt.Printf("%s.statstable.%s.n_tup_ins %d %d\n", plugin.Scheme, dbDatabase, nTupIns, timestamp)
+	fmt.Printf("%s.statstable.%s.n_tup_upd %d %d\n", plugin.Scheme, dbDatabase, nTupUpd, timestamp)
+	fmt.Printf("%s.statstable.%s.n_tup_del %d %d\n", plugin.Scheme, dbDatabase, nTupDel, timestamp)
+	fmt.Printf("%s.statstable.%s.n_tup_hot_upd %d %d\n", plugin.Scheme, dbDatabase, nTupHotUpd, timestamp)
+	fmt.Printf("%s.statstable.%s.n_live_tup %d %d\n", plugin.Scheme, dbDatabase, nLiveTup, timestamp)
+	fmt.Printf("%s.statstable.%s.n_dead_tup %d %d\n", plugin.Scheme, dbDatabase, nDeadTup, timestamp)
+
+	return nil
+}

--- a/cmd/metric-postgres-statstable/main_test.go
+++ b/cmd/metric-postgres-statstable/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckArgs(t *testing.T) {
+	origPort := plugin.Port
+	origIniFile := plugin.IniFile
+	origScope := plugin.Scope
+	defer func() {
+		plugin.Port = origPort
+		plugin.IniFile = origIniFile
+		plugin.Scope = origScope
+	}()
+
+	t.Run("valid defaults", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.Scope = "user"
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("valid scope all", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.Scope = "all"
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid scope", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.Scope = "system"
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for invalid scope")
+		}
+	})
+
+	t.Run("empty scope", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.Scope = ""
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for empty scope")
+		}
+	})
+
+	t.Run("invalid port", func(t *testing.T) {
+		plugin.Port = 0
+		plugin.IniFile = ""
+		plugin.Scope = "user"
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for port 0")
+		}
+	})
+
+	t.Run("valid ini file", func(t *testing.T) {
+		tmpFile := filepath.Join(t.TempDir(), "pgpass")
+		if err := os.WriteFile(tmpFile, []byte("localhost:5432:*:user:pass"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		plugin.Port = 5432
+		plugin.IniFile = tmpFile
+		plugin.Scope = "user"
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("nonexistent ini file", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = "/nonexistent/path/pgpass"
+		plugin.Scope = "user"
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for nonexistent ini file")
+		}
+	})
+}

--- a/cmd/metrics-postgres-query/main.go
+++ b/cmd/metrics-postgres-query/main.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgpassfile"
+	"github.com/jackc/pgx/v5"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-plugin-sdk/sensu"
+)
+
+type Config struct {
+	sensu.PluginConfig
+	User        string
+	Password    string
+	IniFile     string
+	Hostname    string
+	Port        int
+	Database    string
+	Sslmode     string
+	Scheme      string
+	Timeout     int
+	Query       string
+	CountTuples bool
+	Multirow    bool
+}
+
+var (
+	plugin = Config{
+		PluginConfig: sensu.PluginConfig{
+			Name:     "metrics-postgres-query",
+			Short:    "postgres query metric",
+			Keyspace: "",
+		},
+	}
+
+	options = []sensu.ConfigOption{
+		&sensu.PluginConfigOption[string]{
+			Path:      "User",
+			Argument:  "user",
+			Shorthand: "u",
+			Usage:     "postgres user to connect",
+			Value:     &plugin.User,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "Password",
+			Argument:  "password",
+			Shorthand: "p",
+			Usage:     "Password for user",
+			Value:     &plugin.Password,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "pgpass file",
+			Argument:  "pgpass",
+			Shorthand: "f",
+			Usage:     "Location of .pgpass file for access to postgres",
+			Value:     &plugin.IniFile,
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "port",
+			Argument:  "port",
+			Shorthand: "P",
+			Usage:     "Port to connect to",
+			Value:     &plugin.Port,
+			Default:   5432,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "hostname",
+			Argument: "hostname",
+			Usage:    "Hostname to login to",
+			Value:    &plugin.Hostname,
+			Default:  "localhost",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "database",
+			Argument:  "database",
+			Shorthand: "d",
+			Usage:     "Database name",
+			Value:     &plugin.Database,
+			Default:   "postgres",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "sslmode",
+			Argument:  "sslmode",
+			Shorthand: "s",
+			Usage:     "SSL mode for connecting to postgres",
+			Value:     &plugin.Sslmode,
+			Default:   "prefer",
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:     "scheme",
+			Argument: "scheme",
+			Usage:    "Metric naming scheme, text to prepend to metric",
+			Value:    &plugin.Scheme,
+			Default:  "postgres",
+		},
+		&sensu.PluginConfigOption[int]{
+			Path:      "timeout",
+			Argument:  "timeout",
+			Shorthand: "T",
+			Usage:     "Connection timeout (seconds)",
+			Value:     &plugin.Timeout,
+			Default:   10,
+		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "query",
+			Argument:  "query",
+			Shorthand: "q",
+			Usage:     "Database query to execute",
+			Value:     &plugin.Query,
+		},
+		&sensu.PluginConfigOption[bool]{
+			Path:      "count-tuples",
+			Argument:  "tuples",
+			Shorthand: "t",
+			Usage:     "Count the number of tuples (rows) returned by the query",
+			Value:     &plugin.CountTuples,
+			Default:   false,
+		},
+		&sensu.PluginConfigOption[bool]{
+			Path:      "multirow",
+			Argument:  "multirow",
+			Shorthand: "m",
+			Usage:     "Return all rows instead of just the first",
+			Value:     &plugin.Multirow,
+			Default:   false,
+		},
+	}
+)
+
+func main() {
+	metric := sensu.NewGoHandler(&plugin.PluginConfig, options, checkArgs, executeMetric)
+	metric.Execute()
+}
+
+func checkArgs(_ *corev2.Event) error {
+	if plugin.Port <= 1 || plugin.Port >= 65535 {
+		return fmt.Errorf("invalid port, should be a value between 1 and 65535")
+	}
+	if plugin.IniFile != "" {
+		if _, err := os.Stat(plugin.IniFile); os.IsNotExist(err) {
+			return fmt.Errorf("unable to open the supplied config file %s", plugin.IniFile)
+		}
+	}
+	if plugin.Query == "" {
+		return fmt.Errorf("query is required")
+	}
+	return nil
+}
+
+func executeMetric(_ *corev2.Event) error {
+	ctx := context.Background()
+	timestamp := time.Now().Unix()
+
+	var dbUser, dbPass, dbHost, dbDatabase string
+	var dbPort int
+	if plugin.IniFile != "" {
+		iniFile, err := pgpassfile.ReadPassfile(plugin.IniFile)
+		if err != nil {
+			return fmt.Errorf("error parsing ini file: %v", err)
+		}
+		for _, entry := range iniFile.Entries {
+			dbUser = entry.Username
+			dbPass = entry.Password
+			dbHost = entry.Hostname
+			dbPort, _ = strconv.Atoi(entry.Port)
+			dbDatabase = entry.Database
+		}
+	} else {
+		dbUser = plugin.User
+		dbPass = plugin.Password
+		dbHost = plugin.Hostname
+		dbPort = plugin.Port
+		dbDatabase = plugin.Database
+	}
+
+	dataSourceName := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&connect_timeout=%d",
+		dbUser, dbPass, dbHost, dbPort, dbDatabase, plugin.Sslmode, plugin.Timeout)
+	db, err := pgx.Connect(ctx, dataSourceName)
+	if err != nil {
+		return fmt.Errorf("error connecting to postgres: %v", err)
+	}
+	defer func() {
+		_ = db.Close(ctx)
+	}()
+
+	rows, err := db.Query(ctx, plugin.Query)
+	if err != nil {
+		return fmt.Errorf("unable to query PostgreSQL: %v", err)
+	}
+	defer rows.Close()
+
+	var results [][]interface{}
+	for rows.Next() {
+		values, err := rows.Values()
+		if err != nil {
+			return fmt.Errorf("error reading query results: %v", err)
+		}
+		results = append(results, values)
+	}
+	if rows.Err() != nil {
+		return fmt.Errorf("error iterating query results: %v", rows.Err())
+	}
+
+	if plugin.CountTuples {
+		fmt.Printf("%s %d %d\n", plugin.Scheme, len(results), timestamp)
+		return nil
+	}
+
+	if plugin.Multirow {
+		for _, row := range results {
+			if len(row) >= 2 {
+				fmt.Printf("%s.%v %v %d\n", plugin.Scheme, row[0], row[1], timestamp)
+			}
+		}
+		return nil
+	}
+
+	// Default: output first row, first value
+	if len(results) == 0 || len(results[0]) == 0 {
+		return fmt.Errorf("query returned no results")
+	}
+	fmt.Printf("%s %v %d\n", plugin.Scheme, results[0][0], timestamp)
+
+	return nil
+}

--- a/cmd/metrics-postgres-query/main_test.go
+++ b/cmd/metrics-postgres-query/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckArgs(t *testing.T) {
+	origPort := plugin.Port
+	origIniFile := plugin.IniFile
+	origQuery := plugin.Query
+	defer func() {
+		plugin.Port = origPort
+		plugin.IniFile = origIniFile
+		plugin.Query = origQuery
+	}()
+
+	t.Run("valid with query", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.Query = "SELECT 1"
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("missing query", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = ""
+		plugin.Query = ""
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for missing query")
+		}
+	})
+
+	t.Run("invalid port", func(t *testing.T) {
+		plugin.Port = 0
+		plugin.IniFile = ""
+		plugin.Query = "SELECT 1"
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for port 0")
+		}
+	})
+
+	t.Run("invalid port too high", func(t *testing.T) {
+		plugin.Port = 65535
+		plugin.IniFile = ""
+		plugin.Query = "SELECT 1"
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for port 65535")
+		}
+	})
+
+	t.Run("valid ini file", func(t *testing.T) {
+		tmpFile := filepath.Join(t.TempDir(), "pgpass")
+		if err := os.WriteFile(tmpFile, []byte("localhost:5432:*:user:pass"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		plugin.Port = 5432
+		plugin.IniFile = tmpFile
+		plugin.Query = "SELECT 1"
+		if err := checkArgs(nil); err != nil {
+			t.Errorf("checkArgs() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("nonexistent ini file", func(t *testing.T) {
+		plugin.Port = 5432
+		plugin.IniFile = "/nonexistent/path/pgpass"
+		plugin.Query = "SELECT 1"
+		if err := checkArgs(nil); err == nil {
+			t.Error("checkArgs() expected error for nonexistent ini file")
+		}
+	})
+}


### PR DESCRIPTION
Complete the Go conversion of sensu-plugins-postgres by implementing all 7 remaining metric collector plugins:

- **metric-postgres-statsbgwriter** — pg_stat_bgwriter metrics (checkpoints, buffers)
- **metric-postgres-statsdb** — per-database stats from pg_stat_database (with --all-databases flag)
- **metric-postgres-statsio** — I/O stats from pg_statio_{scope}_tables
- **metric-postgres-statstable** — table stats from pg_stat_{scope}_tables
- **metric-postgres-graphite** — replication lag metric (master/slave)
- **metric-postgres-relation-size** — top N largest relations by total size
- **metrics-postgres-query** — arbitrary SQL query metric output (with --multirow and --tuples modes)

All plugins follow the established codebase patterns (sensu plugin SDK, pgpass support, Graphite output format). Includes unit tests for checkArgs validation and goreleaser build entries for all new binaries.

This brings the project to full feature parity with the original Ruby [sensu-plugins-postgres](https://github.com/sensu-plugins/sensu-plugins-postgres) (14/14 plugins).
